### PR TITLE
Add CPU based thread limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ make
 After compilation run `Waifu2x-Extension-GUI` (or the launcher) from its build
 folder. Place the realcugan-ncnn-vulkan and realesrgan-ncnn-vulkan executables in
 the same directory so the GUI can invoke them.
+
+### Thread control
+
+By default the application limits its internal thread pool to twice the number
+of detected CPU cores. You can override this via the command line:
+
+```bash
+Waifu2x-Extension-GUI --max-threads 8
+```
+or by editing `settings.ini` and setting `MaxThreadCount`.

--- a/Waifu2x-Extension-QT-Launcher/main.cpp
+++ b/Waifu2x-Extension-QT-Launcher/main.cpp
@@ -6,7 +6,7 @@ int main(int argc, char *argv[])
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);//高分辨率屏幕支持
     QApplication a(argc,argv);
-    MainWindow *w = new MainWindow;
+    MainWindow *w = new MainWindow(0);
     w->show();
     return a.exec();
 }

--- a/Waifu2x-Extension-QT/main.cpp
+++ b/Waifu2x-Extension-QT/main.cpp
@@ -20,13 +20,25 @@
 #include "mainwindow.h"
 
 #include <QApplication>
+#include <QCommandLineParser>
 
 int main(int argc, char *argv[])
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);//高分辨率屏幕支持
     QApplication a(argc,argv);
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Waifu2x-Extension-GUI");
+    parser.addHelpOption();
+    QCommandLineOption maxThreadsOpt(QStringLiteral("max-threads"),
+                                     QStringLiteral("Override global thread limit"),
+                                     QStringLiteral("count"));
+    parser.addOption(maxThreadsOpt);
+    parser.process(a);
+    int overrideThreads = 0;
+    if(parser.isSet(maxThreadsOpt))
+        overrideThreads = parser.value(maxThreadsOpt).toInt();
     a.setQuitOnLastWindowClosed(false);//隐藏无窗口时保持运行
-    MainWindow *w = new MainWindow;
+    MainWindow *w = new MainWindow(overrideThreads);
     w->show();
     return a.exec();
 }

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -22,13 +22,24 @@
 #include <QEventLoop>
 #include <QTimer>
 
-MainWindow::MainWindow(QWidget *parent)
+MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
     qRegisterMetaTypeStreamOperators<QList_QMap_QStrQStr >("QList_QMap_QStrQStr");
-    QThreadPool::globalInstance()->setMaxThreadCount(60);//解除全局线程池的最大线程数量限制
+    globalMaxThreadCount = Settings_Read_value("/settings/MaxThreadCount", 0).toInt();
+    if(maxThreadsOverride > 0) globalMaxThreadCount = maxThreadsOverride;
+    if(globalMaxThreadCount <= 0) {
+        int cores = QThread::idealThreadCount();
+        if(cores < 1) cores = 1;
+        globalMaxThreadCount = cores * 2;
+    }
+    QThreadPool::globalInstance()->setMaxThreadCount(globalMaxThreadCount);
+    ui->spinBox_ThreadNum_image->setMaximum(globalMaxThreadCount);
+    ui->spinBox_ThreadNum_gif_internal->setMaximum(globalMaxThreadCount);
+    ui->spinBox_ThreadNum_video_internal->setMaximum(globalMaxThreadCount);
+    if(ui->spinBox_NumOfThreads_VFI) ui->spinBox_NumOfThreads_VFI->setMaximum(globalMaxThreadCount);
     //==============
     this->setWindowTitle("Waifu2x-Extension-GUI "+VERSION+" by Aaron Feng");
     //==============

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -76,7 +76,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(int maxThreadsOverride = 0, QWidget *parent = nullptr);
     void changeEvent(QEvent *e);
     //=======================
     QString VERSION = "v3.41.02-beta";//软件版本号
@@ -89,6 +89,7 @@ public:
     TopSupportersList *TopSupportersList_widget;
     //=======
     QString Current_Path = qApp->applicationDirPath();//当前路径
+    int globalMaxThreadCount = 0; // maximum threads for global pool
     //=======
     void Set_Font_fixed();
     //=================================  File 文件 =================================

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -50,6 +50,7 @@ int MainWindow::Settings_Save()
     configIniWrite->setValue("/settings/ImageThreadNum", ui->spinBox_ThreadNum_image->value());
     configIniWrite->setValue("/settings/GIFThreadNumInternal", ui->spinBox_ThreadNum_gif_internal->value());
     configIniWrite->setValue("/settings/VideoThreadNumInternal", ui->spinBox_ThreadNum_video_internal->value());
+    configIniWrite->setValue("/settings/MaxThreadCount", globalMaxThreadCount);
     //================== Save engine settings =========================
     configIniWrite->setValue("/settings/ImageEngine", ui->comboBox_Engine_Image->currentIndex());
     configIniWrite->setValue("/settings/GIFEngine", ui->comboBox_Engine_GIF->currentIndex());
@@ -316,6 +317,8 @@ int MainWindow::Settings_Read_Apply()
     ui->spinBox_ThreadNum_image->setValue(Settings_Read_value("/settings/ImageThreadNum").toInt());
     ui->spinBox_ThreadNum_gif_internal->setValue(Settings_Read_value("/settings/GIFThreadNumInternal").toInt());
     ui->spinBox_ThreadNum_video_internal->setValue(Settings_Read_value("/settings/VideoThreadNumInternal").toInt());
+    globalMaxThreadCount = Settings_Read_value("/settings/MaxThreadCount", globalMaxThreadCount).toInt();
+    QThreadPool::globalInstance()->setMaxThreadCount(globalMaxThreadCount);
     //================ Load engine settings ================================
     isShowAnime4kWarning=false;
     ui->comboBox_Engine_Image->setCurrentIndex(Settings_Read_value("/settings/ImageEngine").toInt());


### PR DESCRIPTION
## Summary
- add `globalMaxThreadCount` member
- set global thread limit from CPU count
- expose `--max-threads` CLI option
- save/load thread limit in settings
- update README with thread control info

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b510de4208322a0f4f29676771f3d