### PR TITLE
Enable dark mode by default

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -500,7 +500,7 @@ bool MainWindow::SystemPrefersDark() const
 
 void MainWindow::ApplyDarkStyle()
 {
-    int mode = Settings_Read_value("/settings/DarkMode", 2).toInt();
+    int mode = Settings_Read_value("/settings/DarkMode", 1).toInt();
     bool enable = false;
     if(mode == 1)
         enable = true;

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -36,7 +36,7 @@ int MainWindow::Settings_Save()
     //==================== Save version identifier ==================================
     configIniWrite->setValue("/settings/VERSION", VERSION);
     //===== UI style settings =====
-    configIniWrite->setValue("/settings/DarkMode", 2); // 0=light,1=dark,2=auto
+    configIniWrite->setValue("/settings/DarkMode", 1); // 0=light,1=dark,2=auto
     //======= Save scale and denoise values  =================================
     configIniWrite->setValue("/settings/ImageScaleRatio", ui->doubleSpinBox_ScaleRatio_image->value());
     configIniWrite->setValue("/settings/GIFScaleRatio", ui->doubleSpinBox_ScaleRatio_gif->value());


### PR DESCRIPTION
## Summary
- default to dark mode in settings
- read dark mode with the new default when applying styles

## Testing
- `qmake Waifu2x-Extension-QT.pro` *(fails: Opening and ending tag mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684b7035e0d88322b06913c8d918b047