### PR TITLE
Enhance dark theme and refresh widget styles

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include <QFile>
 #include <QPalette>
 #include <QColor>
+#include <QApplication>
 
 MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
     : QMainWindow(parent)
@@ -519,6 +520,13 @@ void MainWindow::ApplyDarkStyle()
     else
     {
         qApp->setStyleSheet("");
+    }
+
+    for(QWidget *w : QApplication::allWidgets())
+    {
+        w->style()->unpolish(w);
+        w->style()->polish(w);
+        w->update();
     }
 }
 

--- a/Waifu2x-Extension-QT/styles/dark.qss
+++ b/Waifu2x-Extension-QT/styles/dark.qss
@@ -33,3 +33,63 @@ QMenuBar, QMenu, QToolBar {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #303030, stop:1 #262626);
     border-bottom: 1px solid #444444;
 }
+
+/* Additional controls for a more skeuomorphic feel */
+QPushButton:disabled {
+    background-color: #3b3b3b;
+    color: #777777;
+    border-color: #4c4c4c;
+}
+QPushButton:checked {
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b3b3b, stop:1 #2a2a2a);
+}
+QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus {
+    border: 1px solid #888888;
+}
+
+QProgressBar {
+    border: 1px solid #555555;
+    border-radius: 3px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2d2d2d, stop:1 #1e1e1e);
+    text-align: center;
+    color: #dddddd;
+}
+QProgressBar::chunk {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #4c8ad9, stop:1 #3768a3);
+    border-radius: 3px;
+    margin: 1px;
+}
+
+QSlider::groove:horizontal {
+    border: 1px solid #444444;
+    height: 6px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3a3a3a, stop:1 #262626);
+    margin: 0 8px;
+}
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #555555, stop:1 #3d3d3d);
+    border: 1px solid #666666;
+    width: 14px;
+    margin: -5px -8px;
+    border-radius: 7px;
+}
+QSlider::handle:horizontal:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #6b6b6b, stop:1 #464646);
+}
+
+QCheckBox, QRadioButton {
+    spacing: 6px;
+}
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px;
+    height: 14px;
+}
+QCheckBox::indicator:unchecked, QRadioButton::indicator:unchecked {
+    border: 1px solid #555555;
+    border-radius: 3px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #393939, stop:1 #2a2a2a);
+}
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    border: 1px solid #4c8ad9;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #4c8ad9, stop:1 #3768a3);
+}


### PR DESCRIPTION
## Summary
- enrich skeuomorphic dark.qss with gradients and states
- refresh widgets after switching dark style

## Testing
- `pytest -q` *(fails: vkCreateInstance failed -9)*

------
https://chatgpt.com/codex/tasks/task_e_684ba394ac90832286303d84eaeda96e