### PR TITLE
Refactor RealESRGAN iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ realcugan-ncnn-vulkan -i input.jpg -o output.png -n 1 -s 2
 realesrgan-ncnn-vulkan -i input.jpg -o output.png -n realesrgan-x4plus -s 4
 ```
 
+### Unsupported scales
+
+If a scale not natively provided by the selected RealESRGAN model is requested,
+the application repeats the model until the next higher multiple is reached.
+When this happens a message is emitted indicating that manual downscaling may be
+required. If the computed sequence cannot satisfy the requested scale at all the
+operation fails with an error.
+
 ### Screenshot
 
 Below is the start-up screen of the optional launcher:

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -389,6 +389,8 @@ public:
     QStringList RealESRGAN_NCNN_Vulkan_PrepareArguments(const QString &inputFile, const QString &outputFile, int currentPassScale, const QString &modelName, int tileSize, const QString &gpuIdOrJobConfig, bool isMultiGPUJob, bool ttaEnabled, const QString &outputFormat);
     bool RealESRGAN_ProcessSingleFileIteratively(const QString &inputFile, const QString &outputFile, int targetScale, int modelNativeScale, const QString &modelName, int tileSize, const QString &gpuIdOrJobConfig, bool isMultiGPUJob, bool ttaEnabled, const QString &outputFormat, int rowNumForStatusUpdate = -1);
     QList<int> CalculateRealESRGANScaleSequence(int targetScale, int modelNativeScale);
+    bool RealESRGAN_SetupTempDir(const QString &inputFile, const QString &outputFile, QDir &tempDir, QString &tempPathBase);
+    void RealESRGAN_CleanupTempDir(const QDir &tempDir);
 
 
     //Anime4k


### PR DESCRIPTION
## Summary
- extract temp dir helpers for RealESRGAN
- simplify RealESRGAN iterative scaling loop
- explain behaviour when using unsupported scales

## Testing
- `pytest -q` *(fails: vkCreateInstance failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ba9a1545c8322890045078eab5f62