### PR TITLE
Handle graceful QProcess termination

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -2891,8 +2891,15 @@ bool MainWindow::runProcess(QProcess *process, const QString &cmd,
     stopTimer.setInterval(200);
     connect(&stopTimer, &QTimer::timeout, [&](){
         if(QProcess_stop && process->state() != QProcess::NotRunning){
-            process->kill();
-            loop.quit();
+            stopTimer.stop();
+            process->terminate();
+            bool finished = process->waitForFinished(1500);
+            if(!finished && process->state() != QProcess::NotRunning){
+                process->kill();
+                process->waitForFinished();
+            }
+            if(loop.isRunning())
+                loop.quit();
         }
     });
 


### PR DESCRIPTION
## Summary
- improve process stop logic in `MainWindow::runProcess`

## Testing
- `pytest -q` *(fails: vkCreateInstance failed -9)*

------
https://chatgpt.com/codex/tasks/task_e_684bc6adb41c8322a1107645b79fafa2