### PR TITLE
Fix QFileInfo leaks

### DIFF
--- a/Waifu2x-Extension-QT/Donate.cpp
+++ b/Waifu2x-Extension-QT/Donate.cpp
@@ -59,8 +59,8 @@ int MainWindow::Donate_DownloadOnlineQRCode()
     emit Send_TextBrowser_NewMessage(tr("Starting to download QR Code image(for [Donate] tab) from Github."));
     DownloadTo(Github_OnlineQRCode_online,Github_OnlineQRCode_local);
     //========= 检查github的文件是否下载成功 =================
-    QFileInfo *Github_OnlineQRCode_QFileInfo = new QFileInfo(Github_OnlineQRCode_local);
-    if(QFile::exists(Github_OnlineQRCode_local)&&(Github_OnlineQRCode_QFileInfo->size()>100000))
+    QFileInfo Github_OnlineQRCode_QFileInfo(Github_OnlineQRCode_local);
+    if(QFile::exists(Github_OnlineQRCode_local)&&(Github_OnlineQRCode_QFileInfo.size()>100000))
     {
         emit Send_TextBrowser_NewMessage(tr("Successfully downloaded QR Code image from Github."));
         emit Send_Donate_ReplaceQRCode(Github_OnlineQRCode_local);
@@ -76,8 +76,8 @@ int MainWindow::Donate_DownloadOnlineQRCode()
         emit Send_TextBrowser_NewMessage(tr("Starting to download QR Code image(for [Donate] tab) from Gitee."));
         DownloadTo(Gitee_OnlineQRCode_online,Gitee_OnlineQRCode_local);
         //========= 检查gitee的文件是否下载成功 =================
-        QFileInfo *Gitee_OnlineQRCode_QFileInfo = new QFileInfo(Gitee_OnlineQRCode_local);
-        if(QFile::exists(Gitee_OnlineQRCode_local)&&(Gitee_OnlineQRCode_QFileInfo->size()>100000))
+        QFileInfo Gitee_OnlineQRCode_QFileInfo(Gitee_OnlineQRCode_local);
+        if(QFile::exists(Gitee_OnlineQRCode_local)&&(Gitee_OnlineQRCode_QFileInfo.size()>100000))
         {
             emit Send_TextBrowser_NewMessage(tr("Successfully downloaded QR Code image from Gitee."));
             emit Send_Donate_ReplaceQRCode(Gitee_OnlineQRCode_local);

--- a/Waifu2x-Extension-QT/Web_Activities.cpp
+++ b/Waifu2x-Extension-QT/Web_Activities.cpp
@@ -32,8 +32,8 @@ bool MainWindow::DownloadTo(QString OnlineLink,QString LocalPath)
     while(!Downlad2.waitForStarted(500)&&!QProcess_stop) {}
     while(!Downlad2.waitForFinished(500)&&!QProcess_stop) {}
     QString Downlad2_OutPutStr = Downlad2.readAllStandardError().toLower();
-    QFileInfo *LocalPath_QFileInfo = new QFileInfo(LocalPath);
-    if(LocalPath_QFileInfo->size()<1 || Downlad2_OutPutStr.contains("saved")==false)QFile::remove(LocalPath);
+    QFileInfo LocalPath_QFileInfo(LocalPath);
+    if(LocalPath_QFileInfo.size()<1 || Downlad2_OutPutStr.contains("saved")==false)QFile::remove(LocalPath);
     return QFile::exists(LocalPath);
 }
 /*

--- a/Waifu2x-Extension-QT/gif.cpp
+++ b/Waifu2x-Extension-QT/gif.cpp
@@ -284,9 +284,9 @@ QString MainWindow::Gif_compressGif(QString gifPath,QString gifPath_compressd)
     }
     //======
     //比较文件大小,判断压缩是否有效
-    QFileInfo *gifPath_QFileInfo = new QFileInfo(gifPath);
-    QFileInfo *gifPath_compressd_QFileInfo = new QFileInfo(gifPath_compressd);
-    if(gifPath_compressd_QFileInfo->size() >= gifPath_QFileInfo->size())
+    QFileInfo gifPath_QFileInfo(gifPath);
+    QFileInfo gifPath_compressd_QFileInfo(gifPath_compressd);
+    if(gifPath_compressd_QFileInfo.size() >= gifPath_QFileInfo.size())
     {
         emit Send_TextBrowser_NewMessage(tr("Failed to optimize gif [")+gifPath+tr("] to reduce storage usage, the optimized gif file will be deleted."));
         QFile::remove(gifPath_compressd);

--- a/Waifu2x-Extension-QT/image.cpp
+++ b/Waifu2x-Extension-QT/image.cpp
@@ -235,8 +235,8 @@ QString MainWindow::SaveImageAs_FormatAndQuality(QString OriginalSourceImage_ful
     QString saveCmd = "\""+program+"\" \""+ScaledImage_fullPath+"\" -quality "+QString::number(ImageQualityLevel,10)+" \""+FinalFile_FullPath+"\"";
     runProcess(&SaveImageAs_QProcess, saveCmd);
     //======
-    QFileInfo *FinalFile_FullPath_QFileInfo = new QFileInfo(FinalFile_FullPath);
-    if((QFile::exists(FinalFile_FullPath)==false) || (FinalFile_FullPath_QFileInfo->size()<1))
+    QFileInfo FinalFile_FullPath_QFileInfo(FinalFile_FullPath);
+    if((QFile::exists(FinalFile_FullPath)==false) || (FinalFile_FullPath_QFileInfo.size()<1))
     {
         QFile::remove(FinalFile_FullPath);
         emit Send_TextBrowser_NewMessage(tr("Error: Can\'t convert [")+ScaledImage_fullPath+tr("] to ")+FinalFile_Ext);


### PR DESCRIPTION
## Summary
- use stack allocated `QFileInfo` objects

## Testing
- `pytest -q` *(fails: vkCreateInstance failed -9)*

------
https://chatgpt.com/codex/tasks/task_e_684bceee37a88322afac85074496d665