### PR TITLE
Refactor screen off process

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -2095,11 +2095,9 @@ Call nircmd to turn off the display
 */
 void MainWindow::TurnOffScreen()
 {
-    QProcess *OffScreen = new QProcess();
-    OffScreen->start("\""+Current_Path+"/nircmd-x64/nircmd.exe\" monitor off");
-    OffScreen->waitForStarted(5000);
-    OffScreen->waitForFinished(5000);
-    OffScreen->kill();
+    QProcess OffScreen;
+    runProcess(&OffScreen,
+               "\"" + Current_Path + "/nircmd-x64/nircmd.exe\" monitor off");
     return;
 }
 /*


### PR DESCRIPTION
## Summary
- use stack-allocated QProcess in `TurnOffScreen`
- run the command through `runProcess`

## Testing
- `pytest -q` *(fails: vkCreateInstance failed -9)*

------
https://chatgpt.com/codex/tasks/task_e_684bd41a092883229efd1edb62996821