### PR TITLE
Remove BOM from Waifu2x-Extension-QT sources

### DIFF
--- a/Waifu2x-Extension-QT/AnimatedPNG.cpp
+++ b/Waifu2x-Extension-QT/AnimatedPNG.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/Current_File_Progress.cpp
+++ b/Waifu2x-Extension-QT/Current_File_Progress.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/CustomResolution.cpp
+++ b/Waifu2x-Extension-QT/CustomResolution.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/Donate.cpp
+++ b/Waifu2x-Extension-QT/Donate.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/Finish_Action.cpp
+++ b/Waifu2x-Extension-QT/Finish_Action.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/Frame_Interpolation.cpp
+++ b/Waifu2x-Extension-QT/Frame_Interpolation.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/Right-click_Menu.cpp
+++ b/Waifu2x-Extension-QT/Right-click_Menu.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/SystemTrayIcon.cpp
+++ b/Waifu2x-Extension-QT/SystemTrayIcon.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/Web_Activities.cpp
+++ b/Waifu2x-Extension-QT/Web_Activities.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/checkupdate.cpp
+++ b/Waifu2x-Extension-QT/checkupdate.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/files.cpp
+++ b/Waifu2x-Extension-QT/files.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/gif.cpp
+++ b/Waifu2x-Extension-QT/gif.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/image.cpp
+++ b/Waifu2x-Extension-QT/image.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/main.cpp
+++ b/Waifu2x-Extension-QT/main.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/progressBar.cpp
+++ b/Waifu2x-Extension-QT/progressBar.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/table.cpp
+++ b/Waifu2x-Extension-QT/table.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/textBrowser.cpp
+++ b/Waifu2x-Extension-QT/textBrowser.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/topsupporterslist.cpp
+++ b/Waifu2x-Extension-QT/topsupporterslist.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/topsupporterslist.h
+++ b/Waifu2x-Extension-QT/topsupporterslist.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify

--- a/Waifu2x-Extension-QT/video.cpp
+++ b/Waifu2x-Extension-QT/video.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (C) 2021  Aaron Feng
 
     This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM bytes from C++ and header files under `Waifu2x-Extension-QT`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684c967a4ce48322aec837d121850c10