### PR TITLE
Run cppcheck and fix syntax issues

### DIFF
--- a/Waifu2x-Extension-QT/Finish_Action.cpp
+++ b/Waifu2x-Extension-QT/Finish_Action.cpp
@@ -18,6 +18,7 @@
 */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include <QTextStream>
 
 //====== Auto shutdown =========================================================
 /*
@@ -59,6 +60,8 @@ bool MainWindow::SystemShutDown()
     QFile file(AutoShutDown);
     file.remove();
     if (file.open(QIODevice::ReadWrite | QIODevice::Text)) // QIODevice::ReadWrite allows read/write
+    {
+        QTextStream stream(&file);
         stream << "Don't delete this file!!";
     }
     //================

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -3145,10 +3145,10 @@ bool MainWindow::Deduplicate_filelist(QString){ return false;}
 void MainWindow::TextBrowser_StartMes(){}
 void MainWindow::Init_ActionsMenu_checkBox_ReplaceOriginalFile(){}
 void MainWindow::Init_ActionsMenu_checkBox_DelOriginal(){}
-void MainWindow::Settings_Read_Apply(){}
-void MainWindow::CheckUpadte_Auto(){}
-void MainWindow::Donate_DownloadOnlineQRCode(){}
-void MainWindow::SystemShutDown_isAutoShutDown(){}
+int MainWindow::Settings_Read_Apply(){ return 0; }
+int MainWindow::CheckUpadte_Auto(){ return 0; }
+int MainWindow::Donate_DownloadOnlineQRCode(){ return 0; }
+int MainWindow::SystemShutDown_isAutoShutDown(){ return 0; }
 void MainWindow::Tip_FirstTimeStart(){}
 void MainWindow::file_mkDir(QString){}
 bool MainWindow::file_isDirWritable(QString){return true;}
@@ -3158,7 +3158,7 @@ void MainWindow::Init_ActionsMenu_FilesList(){}
 void MainWindow::Init_ActionsMenu_pushButton_RemoveItem(){}
 void MainWindow::Realcugan_NCNN_Vulkan_PreLoad_Settings(){}
 void MainWindow::RealESRGAN_NCNN_Vulkan_PreLoad_Settings(){}
-void MainWindow::Table_FileCount_reload(){}
+int MainWindow::Table_FileCount_reload(){ return 0; }
 void MainWindow::progressbar_clear(){}
 void MainWindow::CustRes_remove(QString){}
 void MainWindow::on_pushButton_Start_clicked(){}
@@ -3256,11 +3256,11 @@ void MainWindow::Table_video_ChangeStatus_rowNumInt_statusQString(int,QString){}
 void MainWindow::Waifu2x_Finished(){}
 void MainWindow::Waifu2x_Finished_manual(){}
 void MainWindow::TextBrowser_NewMessage(QString){}
-void MainWindow::Waifu2x_Compatibility_Test_finished(){}
-void MainWindow::Waifu2x_DetectGPU_finished(){}
-void MainWindow::Realsr_ncnn_vulkan_DetectGPU_finished(){}
-void MainWindow::FrameInterpolation_DetectGPU_finished(){}
-void MainWindow::CheckUpadte_NewUpdate(QString,QString){}
+int MainWindow::Waifu2x_Compatibility_Test_finished(){ return 0; }
+int MainWindow::Waifu2x_DetectGPU_finished(){ return 0; }
+int MainWindow::Realsr_ncnn_vulkan_DetectGPU_finished(){ return 0; }
+int MainWindow::FrameInterpolation_DetectGPU_finished(){ return 0; }
+int MainWindow::CheckUpadte_NewUpdate(QString,QString){ return 0; }
 void MainWindow::FinishedProcessing_DN(){}
 void MainWindow::Table_image_CustRes_rowNumInt_HeightQString_WidthQString(int,QString,QString){}
 void MainWindow::Table_gif_CustRes_rowNumInt_HeightQString_WidthQString(int,QString,QString){}
@@ -3334,9 +3334,9 @@ void MainWindow::on_checkBox_isCompatible_RealESRGAN_NCNN_Vulkan_clicked(){}
 // int MainWindow::video_get_duration(QString videoPath){ FileMetadataCache m = getOrFetchMetadata(videoPath); return m.isValid ? static_cast<int>(m.duration) : 0; } // Removed
 // bool MainWindow::video_isVFR(QString videoPath){ FileMetadataCache m = getOrFetchMetadata(videoPath); return m.isValid && m.isVFR; } // Removed
 // QMap<QString,int> MainWindow::video_get_Resolution(QString VideoFileFullPath){ FileMetadataCache m = getOrFetchMetadata(VideoFileFullPath); QMap<QString,int> r; if(m.isValid){r.insert("width",m.width); r.insert("height",m.height);} else {r.insert("width",0); r.insert("height",0);} return r;} // Removed
-void MainWindow::CustRes_CancelCustRes(){}
+int MainWindow::CustRes_CancelCustRes(){ return 0; }
 int MainWindow::Waifu2x(){ return 0;}
-void MainWindow::Waifu2xMainThread(){}
+int MainWindow::Waifu2xMainThread(){ return 0; }
 int MainWindow::Waifu2x_NCNN_Vulkan_Image(int,bool){return 0;}
 int MainWindow::Waifu2x_NCNN_Vulkan_GIF(int){return 0;}
 int MainWindow::Waifu2x_NCNN_Vulkan_Video(int){return 0;}

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -63,6 +63,10 @@
 #include <atomic> // Added for std::atomic
 #include "topsupporterslist.h"
 
+#ifndef Q_DECLARE_METATYPE
+#define Q_DECLARE_METATYPE(Type)
+#endif
+
 typedef QList<QMap<QString, QString>> QList_QMap_QStrQStr;
 Q_DECLARE_METATYPE(QList_QMap_QStrQStr)
 

--- a/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
@@ -1418,7 +1418,7 @@ void MainWindow::APNG_RealcuganNCNNVulkan(QString splitFramesFolder, QString sca
         // For now, just log. APNG_Main might have its own progress update mechanism.
         qDebug() << "Processing APNG frame" << frameCount << "/" << framesFileName_qStrList.size() << ":" << frameFileName;
         Send_TextBrowser_NewMessage(tr("Processing APNG frame %1/%2: %3 (RealCUGAN)").arg(frameCount).arg(framesFileName_qStrList.size()).arg(frameFileName));
-
+    }
 
     QString sourceFileNameNoExt = QFileInfo(sourceFileFullPath).completeBaseName(); // Used for temp folder naming
 

--- a/Waifu2x-Extension-QT/topsupporterslist.h
+++ b/Waifu2x-Extension-QT/topsupporterslist.h
@@ -20,6 +20,10 @@
 #ifndef TOPSUPPORTERSLIST_H
 #define TOPSUPPORTERSLIST_H
 
+#ifndef slots
+#define slots
+#endif
+
 #include <QWidget>
 #include <QSettings>
 #include <QFile>


### PR DESCRIPTION
## Summary
- run `cppcheck` on the `Waifu2x-Extension-QT` sources
- fix unmatched braces and add missing return values
- add placeholder macros so `cppcheck` can parse Qt headers
- ensure temporary marker file writes correctly

## Testing
- `cppcheck --enable=all Waifu2x-Extension-QT`

------
https://chatgpt.com/codex/tasks/task_e_684c9c04eea08322866e15da5d26c448