### PR TITLE
Add Python requirements and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,14 @@ Below is the start-up screen of the optional launcher:
 
 The repository includes Pytest cases which exercise the RealCUGAN and RealESRGAN
 binaries on small sample images. Running the suite requires the `pytest` Python
-package and an internet connection. The tests automatically download the Linux
-releases of both upscalers if the executables are not present and place them in
-`tests/bin/`.
+package and an internet connection. Install the test dependencies using:
+
+```bash
+pip install -r requirements.txt
+```
+
+The tests automatically download the Linux releases of both upscalers if the executables
+are not present and place them in `tests/bin/`.
 
 To execute the tests from the repository root simply run:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Pillow>=10.0
+pytest


### PR DESCRIPTION
## Summary
- add `requirements.txt` with Pillow and pytest
- instruct README users to install requirements before testing

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: vkCreateInstance failed / many subfailures)*

------
https://chatgpt.com/codex/tasks/task_e_684ca8e1b3c0832282c6cbfd82297cf9