### PR TITLE
Add cppcheck workflow

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,25 @@
+name: cppcheck
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Qt and cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qtbase5-dev cppcheck
+      - name: Run cppcheck
+        run: |
+          ./tools/run_cppcheck.sh
+          cat cppcheck.log
+      - name: Upload cppcheck log
+        uses: actions/upload-artifact@v3
+        with:
+          name: cppcheck-log
+          path: cppcheck.log

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The sample images used for testing are located under
 `realcugan-ncnn-vulkan SRC/images/` and in the
 `realesrgan-ncnn-vulkan-20220424-windows` folder.
 
-## Static Analysis
+## Static Analysis [![cppcheck](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml/badge.svg)](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml)
 
 Static analysis can be performed with [cppcheck](https://cppcheck.sourceforge.io/). The helper script expects the Qt development headers to be present. On Debian-based distributions install them with:
 
@@ -145,4 +145,4 @@ Run cppcheck from the repository root:
 ./tools/run_cppcheck.sh
 ```
 
-The results are written to `cppcheck.log`.
+The results are written to `cppcheck.log`. A GitHub Actions workflow runs cppcheck on each push and pull request.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run cppcheck
- publish cppcheck log as an artifact
- document cppcheck CI workflow and include a badge in README

## Testing
- `./tools/run_cppcheck.sh` *(fails: not shown? placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_684ce936c45c8322a2f1ec0bd2842333