### PR TITLE
Fix cppcheck macro handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,7 @@ Run cppcheck from the repository root:
 ./tools/run_cppcheck.sh
 ```
 
+The helper script automatically applies the arguments listed in
+`tools/cppcheck.cfg`. This file defines the Qt keywords (`slots`,
+`signals`, `Q_OBJECT`, …) so that cppcheck does not warn about them.
 The results are written to `cppcheck.log`. A GitHub Actions workflow runs cppcheck on each push and pull request.

--- a/tools/cppcheck.cfg
+++ b/tools/cppcheck.cfg
@@ -1,3 +1,3 @@
--Dslots=public
--Dsignals=public
+-Dslots=
+-Dsignals=
 -DQ_OBJECT=


### PR DESCRIPTION
## Summary
- update cppcheck.cfg so Qt keywords don't trigger `unknownMacro`
- document the cppcheck configuration in README

## Testing
- `pytest`
- `./tools/run_cppcheck.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_684cfffa23348322a582e1bb7036e65f