### PR TITLE
Fix Task initialization

### DIFF
--- a/realcugan-ncnn-vulkan SRC/src/main.cpp
+++ b/realcugan-ncnn-vulkan SRC/src/main.cpp
@@ -119,6 +119,7 @@ static void print_usage()
 class Task
 {
 public:
+    Task() : id(0), webp(0), scale(1) {}
     int id;
     int webp;
     int scale;


### PR DESCRIPTION
## Summary
- prevent uninitialized values in `Task` by adding a default constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0245b6d0832293a601bc72be7f8c