### PR TITLE
Fix memory cleanup macros in stb_image_write

### DIFF
--- a/realcugan-ncnn-vulkan SRC/src/stb_image_write.h
+++ b/realcugan-ncnn-vulkan SRC/src/stb_image_write.h
@@ -808,7 +808,13 @@ STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const 
 
 #define stbiw__sbpush(a, v)      (stbiw__sbmaybegrow(a,1), (a)[stbiw__sbn(a)++] = (v))
 #define stbiw__sbcount(a)        ((a) ? stbiw__sbn(a) : 0)
-#define stbiw__sbfree(a)         ((a) ? STBIW_FREE(stbiw__sbraw(a)),0 : 0)
+#define stbiw__sbfree(a)         \
+   do {                          \
+      if (a) {                   \
+         STBIW_FREE(stbiw__sbraw(a)); \
+         (a) = NULL;             \
+      }                          \
+   } while (0)
 
 static void *stbiw__sbgrowf(void **arr, int increment, int itemsize)
 {
@@ -965,7 +971,7 @@ STBIWDEF unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, i
       stbiw__zlib_add(0,1);
 
    for (i=0; i < stbiw__ZHASH; ++i)
-      (void) stbiw__sbfree(hash_table[i]);
+      stbiw__sbfree(hash_table[i]);
    STBIW_FREE(hash_table);
 
    {


### PR DESCRIPTION
## Summary
- improve `stbiw__sbfree` to clear the pointer after freeing
- adjust `stbiw__sbfree` calls in `stb_image_write.h`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0829b6bc83229d466a7bf97b07ea