### PR TITLE
Fix metadata validation timing

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -59,7 +59,6 @@ FileMetadataCache MainWindow::getOrFetchMetadata(const QString &filePath)
 
     if (isVideo) {
         metadata.isAnimated = false;
-        metadata.isValid = true;
         QProcess ffprobeProcess;
         QString ffprobePath = Current_Path + "/ffmpeg/ffprobe_waifu2xEX.exe";
         QStringList args;
@@ -109,6 +108,7 @@ FileMetadataCache MainWindow::getOrFetchMetadata(const QString &filePath)
                         break;
                     }
                 }
+                metadata.isValid = true;
             } else {
                 qDebug() << "Failed to parse ffprobe JSON output for" << filePath << ":" << stdOut << stdErr;
                 metadata.isValid = false;


### PR DESCRIPTION
## Summary
- move `metadata.isValid` assignment after ffprobe parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d169f6938832286768273d1664ff2