### PR TITLE
Start rebranding to Beya_Waifu

### DIFF
--- a/FFmpeg_Encoders_List_waifu2xEX.bat
+++ b/FFmpeg_Encoders_List_waifu2xEX.bat
@@ -1,6 +1,6 @@
 @echo off
 color f0
-title = FFmpeg encoders list - @Waifu2x-Extension-GUI
+title = FFmpeg encoders list - @Beya_Waifu
 cd /d %~dp0
 cls
 ffmpeg_waifu2xEX.exe -hide_banner -loglevel panic -encoders

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Waifu2x-Extension-GUI
+# Beya_Waifu
 
-Waifu2x-Extension-GUI is a Qt based graphical interface for upscaling and denoising images or
+Beya_Waifu is a Qt based graphical interface for upscaling and denoising images or
 videos. The project integrates the RealCUGAN and RealESRGAN upscalers and presents them in a
 single GUI.
 
@@ -37,7 +37,7 @@ qmake Waifu2x-Extension-QT-Launcher.pro
 make
 ```
 
-After compilation run `Waifu2x-Extension-GUI` (or the launcher) from its build
+After compilation run `Beya_Waifu` (or the launcher) from its build
 folder. Place the realcugan-ncnn-vulkan and realesrgan-ncnn-vulkan executables in
 the same directory so the GUI can invoke them.
 
@@ -47,7 +47,7 @@ By default the application limits its internal thread pool to twice the number
 of detected CPU cores. You can override this via the command line:
 
 ```bash
-Waifu2x-Extension-GUI --max-threads 8
+Beya_Waifu --max-threads 8
 ```
 or by editing `settings.ini` and setting `MaxThreadCount`.
 
@@ -69,7 +69,7 @@ are available on the official release pages:
 
 Download and extract the archive for your operating system, then copy the
 contents so that `realcugan-ncnn-vulkan` and `realesrgan-ncnn-vulkan` can be
-found in the same directory as `Waifu2x-Extension-GUI`.
+found in the same directory as `Beya_Waifu`.
 
 ### Command line examples
 
@@ -96,7 +96,7 @@ operation fails with an error.
 
 Below is the start-up screen of the optional launcher:
 
-![GUI screenshot](Waifu2x-Extension-QT-Launcher/TitleImage.png)
+![GUI screenshot](Waifu2x-Extension-QT-Launcher/NuTitleImageDark.png)
 
 ### Troubleshooting
 

--- a/Waifu2x-Extension-QT-Launcher/Waifu2x-Extension-QT-Launcher.pro
+++ b/Waifu2x-Extension-QT-Launcher/Waifu2x-Extension-QT-Launcher.pro
@@ -35,6 +35,6 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 RESOURCES += \
     pic.qrc
 
-TARGET = Waifu2x-Extension-GUI-Launcher
+TARGET = Beya_Waifu-Launcher
 
 RC_ICONS =icon/icon.ico

--- a/Waifu2x-Extension-QT-Launcher/mainwindow.cpp
+++ b/Waifu2x-Extension-QT-Launcher/mainwindow.cpp
@@ -31,7 +31,7 @@ void MainWindow::RUN_Concurrent()
     QProcess get_tasklist;
     QByteArray taskOutput;
     runProcess(&get_tasklist, "tasklist", &taskOutput);
-    if(taskOutput.contains("Waifu2x-Extension-GUI.exe"))
+    if(taskOutput.contains("Beya_Waifu.exe"))
     {
         emit Send_Duplicate();
         QThread::sleep(5);
@@ -82,11 +82,11 @@ void MainWindow::RUN_SLOT()
     {
         ui->label_status->setText("Please grant administrator rights to\n"
                                   "ensure the normal operation of the software.");
-        ShellExecuteW(NULL, QString("runas").toStdWString().c_str(), QString(Current_Path+"/Waifu2x-Extension-GUI.exe").toStdWString().c_str(), QString(Current_Path+"/Waifu2x-Extension-GUI.exe").toStdWString().c_str(), NULL, 1);
+        ShellExecuteW(NULL, QString("runas").toStdWString().c_str(), QString(Current_Path+"/Beya_Waifu.exe").toStdWString().c_str(), QString(Current_Path+"/Beya_Waifu.exe").toStdWString().c_str(), NULL, 1);
         this->close();
         return;
     }
-    ShellExecuteW(NULL, QString("open").toStdWString().c_str(), QString(Current_Path+"/Waifu2x-Extension-GUI.exe").toStdWString().c_str(), NULL, NULL, 1);
+    ShellExecuteW(NULL, QString("open").toStdWString().c_str(), QString(Current_Path+"/Beya_Waifu.exe").toStdWString().c_str(), NULL, NULL, 1);
     this->close();
     return;
 }

--- a/Waifu2x-Extension-QT-Launcher/mainwindow.ui
+++ b/Waifu2x-Extension-QT-Launcher/mainwindow.ui
@@ -65,9 +65,9 @@
     </property>
     <item row="0" column="0">
      <widget class="QLabel" name="label">
-      <property name="styleSheet">
-       <string notr="true">image: url(:/new/prefix1/TitleImage.png);</string>
-      </property>
+        <property name="styleSheet">
+         <string notr="true">image: url(:/new/prefix1/NuTitleImageDark.png);</string>
+        </property>
       <property name="text">
        <string/>
       </property>

--- a/Waifu2x-Extension-QT-Launcher/pic.qrc
+++ b/Waifu2x-Extension-QT-Launcher/pic.qrc
@@ -1,5 +1,5 @@
 <RCC>
     <qresource prefix="/new/prefix1">
-        <file>TitleImage.png</file>
+        <file>NuTitleImageDark.png</file>
     </qresource>
 </RCC>

--- a/Waifu2x-Extension-QT/Donate.cpp
+++ b/Waifu2x-Extension-QT/Donate.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -28,8 +28,8 @@ int MainWindow::Donate_DownloadOnlineQRCode()
     //============================
     //     Update supporter list
     //============================
-    QString Github_TopSupporterList_online = "https://raw.githubusercontent.com/AaronFeng753/Waifu2x-Extension-GUI/master/.github/TopSupportersList_W2xEX.ini";
-    QString Gitee_TopSupporterList_online = "https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/raw/master/.github/TopSupportersList_W2xEX.ini";
+    QString Github_TopSupporterList_online = "https://raw.githubusercontent.com/beyawnko/Beya_Waifu/master/.github/TopSupportersList_W2xEX.ini";
+    QString Gitee_TopSupporterList_online = "https://gitee.com/beyawnko/Beya_Waifu/raw/master/.github/TopSupportersList_W2xEX.ini";
     QString TopSupporterList_local = Current_Path+"/TopSupportersList_W2xEX.ini";
     QFile::remove(TopSupporterList_local);
     //===
@@ -50,8 +50,8 @@ int MainWindow::Donate_DownloadOnlineQRCode()
     //============================
     //     Update QR code image
     //============================
-    QString Github_OnlineQRCode_online = "https://raw.githubusercontent.com/AaronFeng753/Waifu2x-Extension-GUI/master/.github/Online_Donate_QRCode.jpg";
-    QString Gitee_OnlineQRCode_online = "https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/raw/master/.github/Online_Donate_QRCode.jpg";
+    QString Github_OnlineQRCode_online = "https://raw.githubusercontent.com/beyawnko/Beya_Waifu/master/.github/Online_Donate_QRCode.jpg";
+    QString Gitee_OnlineQRCode_online = "https://gitee.com/beyawnko/Beya_Waifu/raw/master/.github/Online_Donate_QRCode.jpg";
     //=
     QString Github_OnlineQRCode_local = Current_Path+"/Online_Donate_QRCode_Github.jpg";
     QString Gitee_OnlineQRCode_local = Current_Path+"/Online_Donate_QRCode_Gitee.jpg";
@@ -104,7 +104,7 @@ void MainWindow::Donate_ReplaceQRCode(QString QRCodePath)
 
 void MainWindow::FinishedProcessing_DN()
 {
-    QMessageBox Msg(QMessageBox::Question, QString(tr("Notification")+" @Waifu2x-Extension-GUI"), QString(tr("Please donate to support the developers, so we can bring further updates for this software, thank you!\n\n"
+    QMessageBox Msg(QMessageBox::Question, QString(tr("Notification")+" @Beya_Waifu"), QString(tr("Please donate to support the developers, so we can bring further updates for this software, thank you!\n\n"
                     "If you don't wanna see this notification anymore, you can get the Premium version by support me on Patreon.")));
     Msg.setIcon(QMessageBox::Information);
     QAbstractButton *pYesBtn = Msg.addButton(QString(" "+tr("Get Premium version")+" "), QMessageBox::YesRole);

--- a/Waifu2x-Extension-QT/SystemTrayIcon.cpp
+++ b/Waifu2x-Extension-QT/SystemTrayIcon.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -37,7 +37,7 @@ void MainWindow::Init_SystemTrayIcon()
 {
     // Initialize the icon
     systemTray->setIcon(*MainIcon_QIcon);
-    systemTray->setToolTip(tr("Waifu2x-Extension-GUI\nRight-click to show the menu."));
+    systemTray->setToolTip(tr("Beya_Waifu\nRight-click to show the menu."));
     // Initialize click actions
     connect(systemTray,SIGNAL(activated(QSystemTrayIcon::ActivationReason)),this,SLOT(on_activatedSysTrayIcon(QSystemTrayIcon::ActivationReason)),Qt::UniqueConnection);
     // Initialize menu actions

--- a/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
+++ b/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
@@ -1,4 +1,4 @@
-#    Copyright (C) 2021  Aaron Feng
+#    Copyright (C) 2025  beyawnko
 
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -73,7 +73,7 @@ TRANSLATIONS += language_English.ts \
                language_Chinese.ts \
                language_TraditionalChinese.ts
 
-TARGET = Waifu2x-Extension-GUI
+TARGET = Beya_Waifu
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin

--- a/Waifu2x-Extension-QT/Web_Activities.cpp
+++ b/Waifu2x-Extension-QT/Web_Activities.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
@@ -55,7 +55,7 @@ void MainWindow::ConnectivityTest_RawGithubusercontentCom()
     QMutex_ConnectivityTest_RawGithubusercontentCom.lock();
     isConnectivityTest_RawGithubusercontentCom_Running=true;
     //===
-    QString OnlineAddress="https://raw.githubusercontent.com/AaronFeng753/Waifu2x-Extension-GUI/master/.github/ConnectivityTest_githubusercontent.txt";
+    QString OnlineAddress="https://raw.githubusercontent.com/beyawnko/Beya_Waifu/master/.github/ConnectivityTest_githubusercontent.txt";
     QString LocalAddress=Current_Path+"/ConnectivityTest_Waifu2xEX.txt";
     QFile::remove(LocalAddress);
     //===

--- a/Waifu2x-Extension-QT/checkupdate.cpp
+++ b/Waifu2x-Extension-QT/checkupdate.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
@@ -26,9 +26,9 @@ void MainWindow::on_pushButton_CheckUpdate_clicked()
 {
     if(ui->comboBox_language->currentIndex()==1)
     {
-        QDesktopServices::openUrl(QUrl("https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/releases"));
+        QDesktopServices::openUrl(QUrl("https://gitee.com/beyawnko/Beya_Waifu/releases"));
     }
-    QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/releases"));
+    QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/releases"));
 }
 /*
 Automatic update check:
@@ -47,13 +47,13 @@ int MainWindow::CheckUpadte_Auto()
     {
         case 0:
             Current_Ver=LastStableVer;
-            Github_UpdateInfo_online = "https://raw.githubusercontent.com/AaronFeng753/Waifu2x-Extension-GUI/master/.github/Update_Info.ini";
-            Gitee_UpdateInfo_online = "https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/raw/master/.github/Update_Info.ini";
+            Github_UpdateInfo_online = "https://raw.githubusercontent.com/beyawnko/Beya_Waifu/master/.github/Update_Info.ini";
+            Gitee_UpdateInfo_online = "https://gitee.com/beyawnko/Beya_Waifu/raw/master/.github/Update_Info.ini";
             break;
         case 1:
             Current_Ver=LastBetaVer;
-            Github_UpdateInfo_online = "https://raw.githubusercontent.com/AaronFeng753/Waifu2x-Extension-GUI/master/.github/Update_Info_Beta.ini";
-            Gitee_UpdateInfo_online = "https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/raw/master/.github/Update_Info_Beta.ini";
+            Github_UpdateInfo_online = "https://raw.githubusercontent.com/beyawnko/Beya_Waifu/master/.github/Update_Info_Beta.ini";
+            Gitee_UpdateInfo_online = "https://gitee.com/beyawnko/Beya_Waifu/raw/master/.github/Update_Info_Beta.ini";
             break;
         default:
             break;
@@ -165,8 +165,8 @@ int MainWindow::CheckUpadte_NewUpdate(QString update_str,QString Change_log)
             QAbstractButton *pYesBtn_Gitee = Msg.addButton(tr("Download from Gitee"), QMessageBox::YesRole); // Go to Gitee to download
             Msg.addButton(QString(tr("NO")), QMessageBox::NoRole);
             Msg.exec();
-            if (Msg.clickedButton() == pYesBtn_Github)QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/releases/"+update_str.trimmed()));
-            if (Msg.clickedButton() == pYesBtn_Gitee)QDesktopServices::openUrl(QUrl("https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/releases/"+update_str.trimmed()));
+            if (Msg.clickedButton() == pYesBtn_Github)QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/releases/"+update_str.trimmed()));
+            if (Msg.clickedButton() == pYesBtn_Gitee)QDesktopServices::openUrl(QUrl("https://gitee.com/beyawnko/Beya_Waifu/releases/"+update_str.trimmed()));
             return 0;
         }
         else
@@ -174,7 +174,7 @@ int MainWindow::CheckUpadte_NewUpdate(QString update_str,QString Change_log)
             QAbstractButton *pYesBtn = Msg.addButton(QString(tr("YES")), QMessageBox::YesRole);
             Msg.addButton(QString(tr("NO")), QMessageBox::NoRole);
             Msg.exec();
-            if (Msg.clickedButton() == pYesBtn)QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/releases/"+update_str.trimmed()));
+            if (Msg.clickedButton() == pYesBtn)QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/releases/"+update_str.trimmed()));
             return 0;
         }
     }

--- a/Waifu2x-Extension-QT/files.cpp
+++ b/Waifu2x-Extension-QT/files.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -617,7 +617,7 @@ bool MainWindow::file_generateMarkFile(QString FileFullPath,QString Msg)
         QTextStream stream(&file);
         if(Msg.trimmed() == "")
         {
-            stream << "Waifu2x-Extension-GUI\nDo NOT delete this file!!";
+            stream << "Beya_Waifu\nDo NOT delete this file!!";
         }
         else
         {

--- a/Waifu2x-Extension-QT/language_English.ts
+++ b/Waifu2x-Extension-QT/language_English.ts
@@ -1090,7 +1090,7 @@ path] or [Delete original files] is enabled*
     </message>
     <message>
         <location filename="mainwindow.ui" line="9728"/>
-        <source>Open Waifu2x-Extension-GUI online wiki.</source>
+        <source>Open Beya_Waifu online wiki.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2296,7 +2296,7 @@ Video: %3</source>
     </message>
     <message>
         <location filename="table.cpp" line="553"/>
-        <source>Save files list @Waifu2x-Extension-GUI</source>
+        <source>Save files list @Beya_Waifu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3111,7 +3111,7 @@ Anime4k GPUs List(user configuration):</oldsource>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <source>Do you really wanna exit Waifu2x-Extension-GUI ?</source>
+        <source>Do you really wanna exit Beya_Waifu ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3243,7 +3243,7 @@ Please wait</source>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="874"/>
-        <source>Select saved files list @Waifu2x-Extension-GUI</source>
+        <source>Select saved files list @Beya_Waifu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3488,7 +3488,7 @@ Restart the software to take effect.</source>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1042"/>
-        <source>Select files @Waifu2x-Extension-GUI</source>
+        <source>Select files @Beya_Waifu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4254,7 +4254,7 @@ If it is still not compatible, please uninstall and reinstall the graphics drive
     </message>
     <message>
         <location filename="SystemTrayIcon.cpp" line="36"/>
-        <source>Waifu2x-Extension-GUI
+        <source>Beya_Waifu
 Right-click to show the menu.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4340,7 +4340,7 @@ display the window, double-click to maximize the window.</source>
     <message>
         <location filename="topsupporterslist.ui" line="20"/>
         <location filename="topsupporterslist.cpp" line="29"/>
-        <source>Top Supporters @Waifu2x-Extension-GUI</source>
+        <source>Top Supporters @Beya_Waifu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Waifu2x-Extension-QT/main.cpp
+++ b/Waifu2x-Extension-QT/main.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);//High-resolution screen support
     QApplication a(argc,argv);
     QCommandLineParser parser;
-    parser.setApplicationDescription("Waifu2x-Extension-GUI");
+    parser.setApplicationDescription("Beya_Waifu");
     parser.addHelpOption();
     QCommandLineOption maxThreadsOpt(QStringLiteral("max-threads"),
                                      QStringLiteral("Override global thread limit"),

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -233,7 +233,7 @@ MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
     ui->spinBox_ThreadNum_gif_internal->setMaximum(globalMaxThreadCount);
     ui->spinBox_ThreadNum_video_internal->setMaximum(globalMaxThreadCount);
     if(ui->spinBox_NumOfThreads_VFI) ui->spinBox_NumOfThreads_VFI->setMaximum(globalMaxThreadCount);
-    this->setWindowTitle("Waifu2x-Extension-GUI "+VERSION+" by Aaron Feng");
+    this->setWindowTitle("Beya_Waifu "+VERSION+" by beyawnko");
     translator = new QTranslator(this);
     ui->tabWidget->setCurrentIndex(1);
     ui->tabWidget->tabBar()->setTabTextColor(0,Qt::red);
@@ -496,7 +496,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
     }
     if(ui->checkBox_PromptWhenExit->isChecked())
     {
-        QMessageBox Msg(QMessageBox::Question, QString(tr("Notification")), QString(tr("Do you really wanna exit Waifu2x-Extension-GUI ?")));
+        QMessageBox Msg(QMessageBox::Question, QString(tr("Notification")), QString(tr("Do you really wanna exit Beya_Waifu ?")));
         Msg.setIcon(QMessageBox::Question);
         QAbstractButton *pYesBtn = Msg.addButton(QString(tr("YES")), QMessageBox::YesRole);
         QAbstractButton *pNoBtn = Msg.addButton(QString(tr("NO")), QMessageBox::NoRole);
@@ -524,7 +524,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
         QProcess_stop = true;
         emit TextBrowser_NewMessage(tr("Trying to stop, please wait..."));
         QMessageBox *MSG_2 = new QMessageBox();
-        MSG_2->setWindowTitle(tr("Notification")+" @Waifu2x-Extension-GUI");
+        MSG_2->setWindowTitle(tr("Notification")+" @Beya_Waifu");
         MSG_2->setText(tr("Waiting for the files processing thread to pause"));
         MSG_2->setIcon(QMessageBox::Information);
         MSG_2->setModal(true);
@@ -535,7 +535,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
     else
     {
         QMessageBox *MSG_2 = new QMessageBox();
-        MSG_2->setWindowTitle(tr("Notification")+" @Waifu2x-Extension-GUI");
+        MSG_2->setWindowTitle(tr("Notification")+" @Beya_Waifu");
         MSG_2->setText(tr("Closing...\n\nPlease wait"));
         MSG_2->setIcon(QMessageBox::Information);
         MSG_2->setModal(true);
@@ -582,7 +582,7 @@ int MainWindow::Force_close()
                  <<"apngdis_waifu2xEX.exe"<<"apngasm_waifu2xEX.exe"<<"RealCUGAN-ncnn-Vulkan_waifu2xEX.exe"<<"RealESRGAN-ncnn-Vulkan_waifu2xEX.exe";
     KILL_TASK_QStringList(TaskNameList,true);
     QProcess Close;
-    Close.start("taskkill /f /t /fi \"imagename eq Waifu2x-Extension-GUI.exe\"");
+    Close.start("taskkill /f /t /fi \"imagename eq Beya_Waifu.exe\"");
     Close.waitForStarted(10000);
     Close.waitForFinished(10000);
     return 0;
@@ -896,19 +896,19 @@ void MainWindow::Play_NFSound()
 
 void MainWindow::on_pushButton_Report_clicked()
 {
-    QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/issues/new"));
+    QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/issues/new"));
 }
 
 void MainWindow::on_pushButton_ReadMe_clicked()
 {
     if(ui->comboBox_language->currentIndex()==1)
     {
-        QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/"));
-        QDesktopServices::openUrl(QUrl("https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/"));
+        QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/"));
+        QDesktopServices::openUrl(QUrl("https://gitee.com/beyawnko/Beya_Waifu/"));
     }
     else
     {
-        QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/"));
+        QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/"));
     }
 }
 
@@ -1109,7 +1109,7 @@ void MainWindow::on_comboBox_language_currentIndexChanged(int index)
 void MainWindow::on_pushButton_ReadFileList_clicked()
 {
     file_mkDir(Current_Path+"/FilesList_W2xEX");
-    QString Table_FileList_ini = QFileDialog::getOpenFileName(this, tr("Select saved files list @Waifu2x-Extension-GUI"), Current_Path+"/FilesList_W2xEX", "*.ini");
+    QString Table_FileList_ini = QFileDialog::getOpenFileName(this, tr("Select saved files list @Beya_Waifu"), Current_Path+"/FilesList_W2xEX", "*.ini");
     if(Table_FileList_ini=="")return;
     if(QFile::exists(Table_FileList_ini))
     {
@@ -1169,12 +1169,12 @@ void MainWindow::on_pushButton_about_clicked()
 {
     QMessageBox *MSG = new QMessageBox();
     MSG->setWindowTitle(tr("About"));
-    QString line1 = "Waifu2x-Extension-GUI\n\n";
+    QString line1 = "Beya_Waifu\n\n";
     QString line2 = VERSION+"\n\n";
-    QString line3 = "Github: https://github.com/AaronFeng753/Waifu2x-Extension-GUI\n\n";
-    QString line4 = "Waifu2x-Extension-GUI is licensed under the\n";
+    QString line3 = "Github: https://github.com/beyawnko/Beya_Waifu\n\n";
+    QString line4 = "Beya_Waifu is licensed under the\n";
     QString line5 = "GNU Affero General Public License v3.0\n\n";
-    QString line6 = "Copyright (C) 2021 Aaron Feng. All rights reserved.\n\n";
+    QString line6 = "Copyright (C) 2025 beyawnko. All rights reserved.\n\n";
     QString line7 = "The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.\n\n";
     QString line8 = "Icons made by : Freepik & Icongeek26 & Roundicons From Flaticon(https://www.flaticon.com/)";
     MSG->setText(line1+line2+line3+line4+line5+line6+line7+line8);
@@ -1274,7 +1274,7 @@ void MainWindow::on_pushButton_BrowserFile_clicked()
         BrowserStartPath = configIniRead->value("/Path").toString();
         if(!QFile::exists(BrowserStartPath))BrowserStartPath = "";
     }
-    QStringList Input_path_List = QFileDialog::getOpenFileNames(this, tr("Select files @Waifu2x-Extension-GUI"), BrowserStartPath,  tr("All file(")+nameFilters_QString+")");
+    QStringList Input_path_List = QFileDialog::getOpenFileNames(this, tr("Select files @Beya_Waifu"), BrowserStartPath,  tr("All file(")+nameFilters_QString+")");
     if(Input_path_List.isEmpty())
     {
         return;
@@ -1340,9 +1340,9 @@ void MainWindow::on_pushButton_wiki_clicked()
 {
     if(ui->comboBox_language->currentIndex()==1)
     {
-        QDesktopServices::openUrl(QUrl("https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI/wikis"));
+        QDesktopServices::openUrl(QUrl("https://gitee.com/beyawnko/Beya_Waifu/wikis"));
     }
-    QDesktopServices::openUrl(QUrl("https://github.com/AaronFeng753/Waifu2x-Extension-GUI/wiki"));
+    QDesktopServices::openUrl(QUrl("https://github.com/beyawnko/Beya_Waifu/wiki"));
 }
 
 void MainWindow::on_pushButton_HideTextBro_clicked()

--- a/Waifu2x-Extension-QT/mainwindow.ui
+++ b/Waifu2x-Extension-QT/mainwindow.ui
@@ -31,9 +31,9 @@
   <property name="focusPolicy">
    <enum>Qt::StrongFocus</enum>
   </property>
-  <property name="windowTitle">
-   <string notr="true">Waifu2x-Extension-GUI by Aaron Feng</string>
-  </property>
+   <property name="windowTitle">
+    <string notr="true">Beya_Waifu by beyawnko</string>
+   </property>
   <property name="windowIcon">
    <iconset resource="icon.qrc">
     <normaloff>:/new/prefix1/icon/icon_main.png</normaloff>:/new/prefix1/icon/icon_main.png</iconset>

--- a/Waifu2x-Extension-QT/table.cpp
+++ b/Waifu2x-Extension-QT/table.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -503,7 +503,7 @@ void MainWindow::on_pushButton_SaveFileList_clicked()
     //Create default folder for saved files
     file_mkDir(Current_Path+"/FilesList_W2xEX");
     //Save file dialog
-    QString FilesListFullPath = QFileDialog::getSaveFileName(this, tr("Save files list @Waifu2x-Extension-GUI"),
+    QString FilesListFullPath = QFileDialog::getSaveFileName(this, tr("Save files list @Beya_Waifu"),
                                 Current_Path+"/FilesList_W2xEX/FilesList_W2xEX_"+QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss")+".ini",
                                 "*.ini");
     if(FilesListFullPath.trimmed()=="")return;

--- a/Waifu2x-Extension-QT/textBrowser.cpp
+++ b/Waifu2x-Extension-QT/textBrowser.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "mainwindow.h"
@@ -45,10 +45,10 @@ void MainWindow::TextBrowser_StartMes()
         CurrentVerState=tr("[Stable]");
     }
     //====
-    ui->textBrowser->append("Waifu2x-Extension-GUI by Aaron Feng");
+    ui->textBrowser->append("Beya_Waifu by beyawnko");
     ui->textBrowser->append(tr("Version:")+" "+VERSION+" "+CurrentVerState);
-    ui->textBrowser->append("Github: https://github.com/AaronFeng753/Waifu2x-Extension-GUI");
-    if(ui->comboBox_language->currentIndex()==1)ui->textBrowser->append("Gitee: https://gitee.com/aaronfeng0711/Waifu2x-Extension-GUI");
+    ui->textBrowser->append("Github: https://github.com/beyawnko/Beya_Waifu");
+    if(ui->comboBox_language->currentIndex()==1)ui->textBrowser->append("Gitee: https://gitee.com/beyawnko/Beya_Waifu");
     ui->textBrowser->append(tr("Please donate to support the developers, so we can bring further updates for this software, thank you! (^_^)/"));
     ui->textBrowser->moveCursor(QTextCursor::End);
 }

--- a/Waifu2x-Extension-QT/topsupporterslist.cpp
+++ b/Waifu2x-Extension-QT/topsupporterslist.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
 
 #include "topsupporterslist.h"
@@ -26,7 +26,7 @@ TopSupportersList::TopSupportersList(QWidget *parent) :
 {
     ui->setupUi(this);
     //=================
-    this->setWindowTitle(tr("Top Supporters @Waifu2x-Extension-GUI"));
+    this->setWindowTitle(tr("Top Supporters @Beya_Waifu"));
     this->setWindowFlags(Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
     ui->textBrowser_SupportersNameList->setText(tr("Failed to update \"Top Supporters List\", following list might be out dated.\n\n")+
             "DiabloTVHD | Teh Pron | PorcelainShrine");

--- a/Waifu2x-Extension-QT/topsupporterslist.ui
+++ b/Waifu2x-Extension-QT/topsupporterslist.ui
@@ -16,9 +16,9 @@
     <height>400</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Top Supporters @Waifu2x-Extension-GUI</string>
-  </property>
+   <property name="windowTitle">
+    <string>Top Supporters @Beya_Waifu</string>
+   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0" colspan="3">
     <widget class="QTextBrowser" name="textBrowser_SupportersNameList">


### PR DESCRIPTION
## Summary
- rename app references from Waifu2x-Extension-GUI to **Beya_Waifu**
- set dark title image for launcher startup screen
- update project metadata and resource paths
- change author notices to `beyawnko` (2025)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684d1d78ce0c83228619939848d8aef8