### PR TITLE
Add liquid glass shader

### DIFF
--- a/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
+++ b/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
@@ -86,6 +86,17 @@ RESOURCES += \
     OtherPic.qrc \
     donate.qrc \
     icon.qrc \
-    style.qrc
+    style.qrc \
+    shaders.qrc
+
+# compile GLSL shader to QSB
+liquidglass_frag.input = SHADER
+liquidglass_frag.files = $$PWD/shaders/liquidglass.frag
+liquidglass_frag.output = $$OUT_PWD/shaders/liquidglass.frag.qsb
+liquidglass_frag.commands = mkdir -p $$OUT_PWD/shaders && \
+    $$[QT_HOST_BINS]/qsb ${QMAKE_FILE_NAME} -o ${QMAKE_FILE_OUT}
+liquidglass_frag.CONFIG = no_link
+QMAKE_EXTRA_TARGETS += liquidglass_frag
+PRE_TARGETDEPS += $$liquidglass_frag.output
 
 RC_ICONS =icon/icon.ico

--- a/Waifu2x-Extension-QT/shaders.qrc
+++ b/Waifu2x-Extension-QT/shaders.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/shaders">
+        <file>shaders/liquidglass.frag.qsb</file>
+    </qresource>
+</RCC>

--- a/Waifu2x-Extension-QT/shaders/liquidglass.frag
+++ b/Waifu2x-Extension-QT/shaders/liquidglass.frag
@@ -1,0 +1,59 @@
+#version 440
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 fragColor;
+
+layout(binding = 0) uniform sampler2D sourceTexture;
+layout(binding = 1) uniform sampler2D environmentTexture;
+
+float sphereSDF(vec3 p, float r)
+{
+    return length(p) - r;
+}
+
+vec3 calcNormal(vec3 p)
+{
+    const vec2 e = vec2(0.001, 0.0);
+    return normalize(vec3(
+        sphereSDF(p + e.xyy, 1.0) - sphereSDF(p - e.xyy, 1.0),
+        sphereSDF(p + e.yxy, 1.0) - sphereSDF(p - e.yxy, 1.0),
+        sphereSDF(p + e.yyx, 1.0) - sphereSDF(p - e.yyx, 1.0)
+    ));
+}
+
+void main()
+{
+    vec2 p = vTexCoord * 2.0 - 1.0;
+    vec3 ro = vec3(0.0, 0.0, -2.5);
+    vec3 rd = normalize(vec3(p, 1.5));
+
+    float t = 0.0;
+    for (int i = 0; i < 64; ++i) {
+        vec3 pos = ro + t * rd;
+        float d = sphereSDF(pos, 1.0);
+        if (abs(d) < 0.001)
+            break;
+        t += d;
+    }
+
+    vec3 pos = ro + t * rd;
+    vec3 n = calcNormal(pos);
+
+    vec3 refl = reflect(rd, n);
+    vec3 refr = refract(rd, n, 1.0 / 1.33);
+
+    vec3 reflCol = texture(environmentTexture, refl.xy * 0.5 + 0.5).rgb;
+    vec3 refrCol = texture(sourceTexture, refr.xy * 0.5 + 0.5).rgb;
+
+    float cShift = 0.003;
+    vec3 chroma = vec3(
+        texture(environmentTexture, refl.xy * 0.5 + 0.5 + vec2(cShift, 0.0)).r,
+        texture(environmentTexture, refl.xy * 0.5 + 0.5).g,
+        texture(environmentTexture, refl.xy * 0.5 + 0.5 - vec2(cShift, 0.0)).b
+    );
+
+    vec3 color = mix(reflCol, refrCol, 0.5);
+    color = mix(color, chroma, 0.3);
+
+    fragColor = vec4(color, 1.0);
+}


### PR DESCRIPTION
## Summary
- add a liquid glass shader using SDF sampling with chromatic aberration
- add shaders.qrc and hook it into the resource list
- compile the shader into QSB as part of the qmake build

## Testing
- `pip install Pillow`
- `pip install pytest-subtests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2c260a888322af473161f3645bb6