### PR TITLE
Add LiquidGlass demo QML

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Beya_Waifu --max-threads 8
 ```
 or by editing `settings.ini` and setting `MaxThreadCount`.
 
+### LiquidGlass demo
+
+A minimal QML example using the liquid glass shader lives under `examples`.
+Start it with the Qt `qml` runtime:
+
+```bash
+cd examples
+qml LiquidGlassDemo.qml
+```
+
 ## RealCUGAN and RealESRGAN
 
 Both upscalers rely on the ncnn Vulkan backend and run without a Python or CUDA

--- a/examples/LiquidGlassDemo.qml
+++ b/examples/LiquidGlassDemo.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import "../Waifu2x-Extension-QT/qml" as Effects
+
+ApplicationWindow {
+    id: window
+    width: 640
+    height: 360
+    visible: true
+    title: qsTr("LiquidGlass Demo")
+    Material.theme: Material.Dark
+
+    Rectangle {
+        id: background
+        anchors.fill: parent
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: "#404040" }
+            GradientStop { position: 1.0; color: "#303030" }
+        }
+    }
+
+    Text {
+        id: label
+        anchors.centerIn: parent
+        text: qsTr("Liquid Glass")
+        color: "#eeeeee"
+        font.pixelSize: 32
+    }
+
+    Effects.LiquidGlass {
+        anchors.centerIn: label
+        width: 200
+        height: 200
+        sourceItem: background
+    }
+}


### PR DESCRIPTION
## Summary
- add an `examples` directory with `LiquidGlassDemo.qml`
- document how to launch the demo

## Testing
- `pytest tests/test_gpu_job_config.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684d310d468c83228aef3a44e1e07c08