### PR TITLE
Add QML loading test

### DIFF
--- a/tests/test_qml_liquidglass.py
+++ b/tests/test_qml_liquidglass.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+import pytest
+from PySide6.QtCore import QUrl
+from PySide6.QtQml import QQmlEngine, QQmlComponent
+from PySide6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_liquidglass_qml_load(qapp):
+    qml_path = Path(__file__).resolve().parents[1] / "Waifu2x-Extension-QT" / "qml" / "LiquidGlass.qml"
+    assert qml_path.exists()
+    engine = QQmlEngine()
+    component = QQmlComponent(engine, QUrl.fromLocalFile(str(qml_path)))
+    if component.status() != QQmlComponent.Ready:
+        errors = [err.toString() for err in component.errors()]
+        pytest.fail("QML failed to load: " + "\n".join(errors))
+    obj = component.create()
+    assert obj is not None


### PR DESCRIPTION
## Summary
- test that LiquidGlass.qml loads without QQmlComponent errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d33ef3bf083229b33afda8bf830d3