### PR TITLE
Improve headless test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ To execute the tests from the repository root simply run:
 pytest
 ```
 
+When running the tests without a display server, set the Qt platform to
+"offscreen" so PySide6 does not attempt to load the native GUI libraries:
+
+```bash
+export QT_QPA_PLATFORM=offscreen
+pytest
+```
+
 The sample images used for testing are located under
 `realcugan-ncnn-vulkan SRC/images/` and in the
 `realesrgan-ncnn-vulkan-20220424-windows` folder.

--- a/tests/test_qml_liquidglass.py
+++ b/tests/test_qml_liquidglass.py
@@ -1,4 +1,5 @@
 import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 from pathlib import Path
 import pytest
 from PySide6.QtCore import QUrl


### PR DESCRIPTION
## Summary
- set `QT_QPA_PLATFORM` before importing Qt for headless test run
- document how to run tests without a display

## Testing
- `pip install -r requirements.txt`
- `apt-get update`
- `apt-get install -y libegl1`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684dc3ead65c8322b67b265b112715c4