### PR TITLE
Improve QProcess error handling

### DIFF
--- a/tests/test_qprocess_failure.py
+++ b/tests/test_qprocess_failure.py
@@ -1,0 +1,23 @@
+import os
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+from PySide6.QtCore import QProcess
+
+
+def test_qprocess_failed_start():
+    process = QProcess()
+    process.start('/nonexistent/binary')
+    assert not process.waitForStarted(500), 'Process unexpectedly started'
+    assert process.error() == QProcess.FailedToStart
+
+
+def test_qprocess_nonzero_exit(tmp_path):
+    script = tmp_path / 'fail.sh'
+    script.write_text('#!/bin/sh\nexit 2\n')
+    script.chmod(0o755)
+
+    process = QProcess()
+    process.start(str(script))
+    assert process.waitForStarted(1000)
+    process.waitForFinished(1000)
+    assert process.exitStatus() == QProcess.NormalExit
+    assert process.exitCode() == 2


### PR DESCRIPTION
## Summary
- warn when QProcess exits abnormally in RealCUGAN and RealESRGAN helpers
- show dialogs on start failures
- add tests covering QProcess failure scenarios

## Testing
- `pytest tests/test_qprocess_failure.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd685517c832280bf78bfd0bc4ba3