### PR TITLE
Add engine index 2 persistence

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -22,6 +22,7 @@
 #include <QSettings>
 #include <QListWidgetItem>
 #include <QDebug>
+#include <QTextCodec>
 
 RealCuganProcessor::RealCuganProcessor(MainWindow *parent)
     : QObject(parent), m_mainWindow(parent)
@@ -45,6 +46,12 @@ void RealCuganProcessor::preLoadSettings()
         m_mainWindow->ui->listWidget_GPUList_MultiGPU_RealCUGAN->addItem(newItem);
     }
     settings.endGroup();
+
+    QSettings iniSettings(QDir::currentPath() + "/settings.ini", QSettings::IniFormat);
+    iniSettings.setIniCodec(QTextCodec::codecForName("UTF-8"));
+    m_mainWindow->ui->comboBox_Engine_Image->setCurrentIndex(iniSettings.value("/settings/ImageEngine", 0).toInt());
+    m_mainWindow->ui->comboBox_Engine_GIF->setCurrentIndex(iniSettings.value("/settings/GIFEngine", 0).toInt());
+    m_mainWindow->ui->comboBox_Engine_Video->setCurrentIndex(iniSettings.value("/settings/VideoEngine", 0).toInt());
     readSettings();
     qDebug() << "Realcugan_NCNN_Vulkan_PreLoad_Settings completed.";
 }

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -671,10 +671,10 @@ int MainWindow::Settings_Read_Apply()
     on_checkBox_ShowInterPro_stateChanged(0);
     //====
     on_comboBox_version_Waifu2xNCNNVulkan_currentIndexChanged(0);
-    on_comboBox_Engine_GIF_currentIndexChanged(0);
+    on_comboBox_Engine_GIF_currentIndexChanged(ui->comboBox_Engine_GIF->currentIndex());
     isShowAnime4kWarning=false;
-    on_comboBox_Engine_Image_currentIndexChanged(0);
-    on_comboBox_Engine_Video_currentIndexChanged(0);
+    on_comboBox_Engine_Image_currentIndexChanged(ui->comboBox_Engine_Image->currentIndex());
+    on_comboBox_Engine_Video_currentIndexChanged(ui->comboBox_Engine_Video->currentIndex());
     on_comboBox_ImageStyle_currentIndexChanged(0);
     on_comboBox_model_vulkan_currentIndexChanged(0);
     ui->spinBox_DenoiseLevel_image->setValue(Settings_Read_value("/settings/ImageDenoiseLevel").toInt());


### PR DESCRIPTION
## Summary
- load engine combo indexes correctly when applying settings
- read engine selections in RealCuganProcessor preload

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684dea74ddb08322a181c9a2a6a4298b