### PR TITLE
It looks like this commit introduces several improvements to Windows …

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -18,6 +18,7 @@
 #include "RealCuganProcessor.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include <QCoreApplication> // Added for applicationDirPath
 #include <QDir>
 #include <QSettings>
 #include <QListWidgetItem>
@@ -126,17 +127,19 @@ QStringList RealCuganProcessor::prepareArguments(const QString &inputFile,
 
 QString RealCuganProcessor::executablePath(bool experimental) const
 {
-    QString base = QDir::currentPath();
-    QString folder = experimental ? "realcugan-ncnn-vulkan Exp" :
-                                    "realcugan-ncnn-vulkan Win";
-    return base + "/" + folder + "/realcugan-ncnn-vulkan.exe";
+    // experimental flag is no longer used to determine path structure here,
+    // as executables are expected to be directly in applicationDirPath.
+    // If different executables are needed for experimental, they should have distinct names.
+    Q_UNUSED(experimental);
+    return QCoreApplication::applicationDirPath() + "/realcugan-ncnn-vulkan.exe";
 }
 
 QString RealCuganProcessor::modelPath(const QString &modelName, bool experimental) const
 {
-    QString base = QDir::currentPath();
-    QString folder = experimental ? "realcugan-ncnn-vulkan Exp" :
-                                    "realcugan-ncnn-vulkan Win";
-    return base + "/" + folder + "/" + modelName;
+    // experimental flag is no longer used to determine path structure here.
+    // Models are expected to be in subdirectories relative to the application path.
+    // e.g. appDir/models-se, appDir/models-pro
+    Q_UNUSED(experimental);
+    return QCoreApplication::applicationDirPath() + "/" + modelName;
 }
 

--- a/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
@@ -18,6 +18,7 @@
 #include "ui_mainwindow.h"
 #include "RealCuganProcessor.h"
 
+#include <QCoreApplication> // Added for safety, though RealCuganProcessor handles paths
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QProcess>

--- a/Waifu2x-Extension-QT/realesrgan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realesrgan_ncnn_vulkan.cpp
@@ -11,6 +11,7 @@
 #include <QRegularExpression>
 #include <QDirIterator>
 #include <QRandomGenerator>
+#include <QCoreApplication> // Added for applicationDirPath
 
 // --- RealESRGAN Specific Helper Functions ---
 
@@ -225,7 +226,7 @@ bool MainWindow::RealESRGAN_ProcessSingleFileIteratively(
         }
 
         QProcess proc;
-        QString exePath = Current_Path + "/realesrgan-ncnn-vulkan-20220424-windows/realesrgan-ncnn-vulkan.exe";
+        QString exePath = QCoreApplication::applicationDirPath() + "/realesrgan-ncnn-vulkan.exe";
         qDebug() << "RealESRGAN Pass" << pass+1 << "Cmd:" << exePath << args.join(" ");
         proc.start(exePath, args);
 
@@ -460,7 +461,7 @@ bool MainWindow::RealESRGAN_ProcessDirectoryIteratively(
         emit Send_TextBrowser_NewMessage(tr("Starting RealESRGAN directory pass %1/%2 (Model Scale: %3x)...").arg(i + 1).arg(scaleSequence.size()).arg(currentPassScaleForExe));
 
         QProcess process;
-        QString exePath = Current_Path + "/realesrgan-ncnn-vulkan-20220424-windows/realesrgan-ncnn-vulkan.exe";
+        QString exePath = QCoreApplication::applicationDirPath() + "/realesrgan-ncnn-vulkan.exe";
         qDebug() << "RealESRGAN_ProcessDirectoryIteratively Pass" << i + 1 << "Cmd:" << exePath << arguments.join(" ");
 
         process.start(exePath, arguments);
@@ -1144,7 +1145,7 @@ void MainWindow::RealESRGAN_ncnn_vulkan_DetectGPU() {
     connect(process, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(RealESRGAN_ncnn_vulkan_DetectGPU_finished(int,QProcess::ExitStatus)));
     connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)), this, SLOT(RealESRGAN_NCNN_Vulkan_DetectGPU_errorOccurred(QProcess::ProcessError)));
 
-    QString exePath = Current_Path + "/realesrgan-ncnn-vulkan-20220424-windows/realesrgan-ncnn-vulkan.exe";
+    QString exePath = QCoreApplication::applicationDirPath() + "/realesrgan-ncnn-vulkan.exe";
     QFileInfo exeCheck(exePath);
     if (!exeCheck.exists() || !exeCheck.isExecutable()) {
         QMessageBox::critical(this, tr("Error"), tr("RealESRGAN executable not found at %1").arg(exePath));

--- a/build_projects.sh
+++ b/build_projects.sh
@@ -14,15 +14,108 @@ qmake Waifu2x-Extension-QT-Launcher.pro
 make
 popd >/dev/null
 
-# Copy prebuilt upscaler binaries if available
+# Handle Upscaler Binaries (Prebuilt or CMake Build) for Windows
 if [[ "$(uname -s)" == MSYS_* || "$(uname -s)" == CYGWIN_* ]]; then
-    for d in "realcugan-ncnn-vulkan Win" "realesrgan-ncnn-vulkan-20220424-windows"; do
-        if [ -d "$d" ]; then
-            echo "Copying contents of $d into build directories"
-            cp -r "$d"/* Waifu2x-Extension-QT/ 2>/dev/null || true
-            cp -r "$d"/* Waifu2x-Extension-QT-Launcher/ 2>/dev/null || true
+    echo "Windows environment detected. Handling upscaler binaries..."
+
+    RESRGAN_SRC_DIR="Real-ESRGAN-ncnn-vulkan-master"
+    RCUGAN_SRC_DIR="realcugan-ncnn-vulkan SRC"
+
+    RESRGAN_PREBUILT_DIR="realesrgan-ncnn-vulkan-20220424-windows"
+    RCUGAN_PREBUILT_DIR="realcugan-ncnn-vulkan Win"
+
+    TARGET_QT_DIR="Waifu2x-Extension-QT"
+    TARGET_LAUNCHER_DIR="Waifu2x-Extension-QT-Launcher"
+
+    # Ensure target directories exist
+    mkdir -p "$TARGET_QT_DIR"
+    mkdir -p "$TARGET_LAUNCHER_DIR"
+
+    # --- Real-ESRGAN ---
+    echo "Handling Real-ESRGAN..."
+    if [ -d "$RESRGAN_PREBUILT_DIR" ]; then
+        echo "Found prebuilt Real-ESRGAN directory: $RESRGAN_PREBUILT_DIR"
+        echo "Copying .exe files from $RESRGAN_PREBUILT_DIR to $TARGET_QT_DIR/"
+        find "$RESRGAN_PREBUILT_DIR" -name "*.exe" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+        echo "Copying .exe files from $RESRGAN_PREBUILT_DIR to $TARGET_LAUNCHER_DIR/"
+        find "$RESRGAN_PREBUILT_DIR" -name "*.exe" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+        echo "Copying .dll files from $RESRGAN_PREBUILT_DIR to $TARGET_QT_DIR/"
+        find "$RESRGAN_PREBUILT_DIR" -name "*.dll" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+        echo "Copying .dll files from $RESRGAN_PREBUILT_DIR to $TARGET_LAUNCHER_DIR/"
+        find "$RESRGAN_PREBUILT_DIR" -name "*.dll" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+    else
+        echo "Prebuilt Real-ESRGAN not found at $RESRGAN_PREBUILT_DIR. Attempting CMake build..."
+        if [ -d "$RESRGAN_SRC_DIR" ]; then
+            echo "Found Real-ESRGAN source directory: $RESRGAN_SRC_DIR"
+            mkdir -p "$RESRGAN_SRC_DIR/build"
+            pushd "$RESRGAN_SRC_DIR/build" >/dev/null
+            echo "Running CMake for Real-ESRGAN..."
+            cmake -G "MSYS Makefiles" .. || { echo "Real-ESRGAN CMake failed. Exiting."; popd >/dev/null; exit 1; }
+            echo "Running make for Real-ESRGAN..."
+            make || { echo "Real-ESRGAN make failed. Exiting."; popd >/dev/null; exit 1; }
+            popd >/dev/null
+            echo "Real-ESRGAN build successful."
+
+            echo "Copying built Real-ESRGAN .exe files to $TARGET_QT_DIR/"
+            find "$RESRGAN_SRC_DIR/build" -name "*.exe" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            find "$RESRGAN_SRC_DIR/build/src" -name "*.exe" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true # Common output location
+            echo "Copying built Real-ESRGAN .exe files to $TARGET_LAUNCHER_DIR/"
+            find "$RESRGAN_SRC_DIR/build" -name "*.exe" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+            find "$RESRGAN_SRC_DIR/build/src" -name "*.exe" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+            echo "Copying built Real-ESRGAN .dll files to $TARGET_QT_DIR/"
+            find "$RESRGAN_SRC_DIR/build" -name "*.dll" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            find "$RESRGAN_SRC_DIR/build/src" -name "*.dll" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            echo "Copying built Real-ESRGAN .dll files to $TARGET_LAUNCHER_DIR/"
+            find "$RESRGAN_SRC_DIR/build" -name "*.dll" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+            find "$RESRGAN_SRC_DIR/build/src" -name "*.dll" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+        else
+            echo "Real-ESRGAN source directory $RESRGAN_SRC_DIR not found. Cannot build. Exiting."
+            exit 1
         fi
-    done
+    fi
+
+    # --- Real-CUGAN ---
+    echo "Handling Real-CUGAN..."
+    if [ -d "$RCUGAN_PREBUILT_DIR" ]; then
+        echo "Found prebuilt Real-CUGAN directory: $RCUGAN_PREBUILT_DIR"
+        echo "Copying .exe files from $RCUGAN_PREBUILT_DIR to $TARGET_QT_DIR/"
+        find "$RCUGAN_PREBUILT_DIR" -name "*.exe" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+        echo "Copying .exe files from $RCUGAN_PREBUILT_DIR to $TARGET_LAUNCHER_DIR/"
+        find "$RCUGAN_PREBUILT_DIR" -name "*.exe" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+        echo "Copying .dll files from $RCUGAN_PREBUILT_DIR to $TARGET_QT_DIR/"
+        find "$RCUGAN_PREBUILT_DIR" -name "*.dll" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+        echo "Copying .dll files from $RCUGAN_PREBUILT_DIR to $TARGET_LAUNCHER_DIR/"
+        find "$RCUGAN_PREBUILT_DIR" -name "*.dll" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+    else
+        echo "Prebuilt Real-CUGAN not found at $RCUGAN_PREBUILT_DIR. Attempting CMake build..."
+        if [ -d "$RCUGAN_SRC_DIR" ]; then
+            echo "Found Real-CUGAN source directory: $RCUGAN_SRC_DIR"
+            mkdir -p "$RCUGAN_SRC_DIR/build"
+            pushd "$RCUGAN_SRC_DIR/build" >/dev/null
+            echo "Running CMake for Real-CUGAN..."
+            cmake -G "MSYS Makefiles" .. || { echo "Real-CUGAN CMake failed. Exiting."; popd >/dev/null; exit 1; }
+            echo "Running make for Real-CUGAN..."
+            make || { echo "Real-CUGAN make failed. Exiting."; popd >/dev/null; exit 1; }
+            popd >/dev/null
+            echo "Real-CUGAN build successful."
+
+            echo "Copying built Real-CUGAN .exe files to $TARGET_QT_DIR/"
+            find "$RCUGAN_SRC_DIR/build" -name "*.exe" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            find "$RCUGAN_SRC_DIR/build/src" -name "*.exe" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            echo "Copying built Real-CUGAN .exe files to $TARGET_LAUNCHER_DIR/"
+            find "$RCUGAN_SRC_DIR/build" -name "*.exe" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+            find "$RCUGAN_SRC_DIR/build/src" -name "*.exe" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+            echo "Copying built Real-CUGAN .dll files to $TARGET_QT_DIR/"
+            find "$RCUGAN_SRC_DIR/build" -name "*.dll" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            find "$RCUGAN_SRC_DIR/build/src" -name "*.dll" -type f -print -exec cp {} "$TARGET_QT_DIR/" \; 2>/dev/null || true
+            echo "Copying built Real-CUGAN .dll files to $TARGET_LAUNCHER_DIR/"
+            find "$RCUGAN_SRC_DIR/build" -name "*.dll" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+            find "$RCUGAN_SRC_DIR/build/src" -name "*.dll" -type f -print -exec cp {} "$TARGET_LAUNCHER_DIR/" \; 2>/dev/null || true
+        else
+            echo "Real-CUGAN source directory $RCUGAN_SRC_DIR not found. Cannot build. Exiting."
+            exit 1
+        fi
+    fi
 fi
 
 echo "Build complete."

--- a/tests/test_upscaler_execution.py
+++ b/tests/test_upscaler_execution.py
@@ -1,0 +1,133 @@
+import subprocess
+import os
+import sys # For platform check
+
+# Define the expected directory where the main application and upscaler binaries are located.
+# This should be relative to the repository root where pytest is typically run.
+APP_DIR = "Waifu2x-Extension-QT"
+
+# Define the names of the upscaler executables.
+# Add .exe for Windows, no extension for Linux/macOS.
+# The build_projects.sh script produces .exe files for Windows (MSYS/CYGWIN).
+# On Linux, the build would produce executables without .exe.
+# For this test, we'll assume we're testing the Windows build output as per the context.
+# If testing on Linux, these would need to be adjusted, or the test made platform-aware.
+
+# For now, let's assume the test runs in an environment where .exe is expected,
+# as the problem description mentions .exe files specifically.
+# If this test were to run on Linux AFTER a Linux build, the names would be different.
+RCUGAN_EXE_NAME = "realcugan-ncnn-vulkan.exe"
+RESRGAN_EXE_NAME = "realesrgan-ncnn-vulkan.exe"
+
+# Timeout for subprocess execution
+TIMEOUT_SECONDS = 20
+
+def test_realcugan_executable_existence_and_run():
+    """
+    Tests if the RealCUGAN executable exists and runs successfully, printing device info.
+    """
+    exe_path = os.path.join(APP_DIR, RCUGAN_EXE_NAME)
+
+    print(f"Checking for RealCUGAN at: {os.path.abspath(exe_path)}")
+    assert os.path.isfile(exe_path), f"{RCUGAN_EXE_NAME} not found at {exe_path}"
+
+    try:
+        # ncnn executables usually list devices and exit 0 when run with no arguments.
+        # On Windows, they might open a console window briefly.
+        # The `creationflags` with `subprocess.CREATE_NO_WINDOW` can hide the window on Windows
+        # but it's not strictly necessary for the test to pass if the window briefly appears.
+        # For cross-platform, just running it is fine.
+        process_kwargs = {
+            "capture_output": True,
+            "text": True,
+            "timeout": TIMEOUT_SECONDS,
+            "check": False  # We check returncode manually
+        }
+        if sys.platform == "win32":
+             # Optional: Hide console window on Windows. Requires Python 3.7+ for CREATE_NO_WINDOW
+             # process_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+             pass
+
+
+        result = subprocess.run([exe_path], **process_kwargs)
+
+        assert result.returncode == 0, \
+            f"{RCUGAN_EXE_NAME} exited with {result.returncode}. Stderr: '{result.stderr}'. Stdout: '{result.stdout}'"
+
+        # Check if stdout or stderr contains "device" (case-insensitive)
+        output_combined = result.stdout.lower() + result.stderr.lower()
+        assert "device" in output_combined, \
+            f"{RCUGAN_EXE_NAME} did not print device info. Combined Output: '{output_combined}'"
+
+    except FileNotFoundError:
+        # This case should ideally be caught by os.path.isfile, but good for robustness.
+        assert False, f"{RCUGAN_EXE_NAME} could not be found to run. Path: {exe_path}"
+    except subprocess.TimeoutExpired:
+        assert False, f"{RCUGAN_EXE_NAME} timed out after {TIMEOUT_SECONDS} seconds."
+
+def test_realesrgan_executable_existence_and_run():
+    """
+    Tests if the RealESRGAN executable exists and runs successfully, printing device info.
+    """
+    exe_path = os.path.join(APP_DIR, RESRGAN_EXE_NAME)
+
+    print(f"Checking for RealESRGAN at: {os.path.abspath(exe_path)}")
+    assert os.path.isfile(exe_path), f"{RESRGAN_EXE_NAME} not found at {exe_path}"
+
+    try:
+        process_kwargs = {
+            "capture_output": True,
+            "text": True,
+            "timeout": TIMEOUT_SECONDS,
+            "check": False
+        }
+        if sys.platform == "win32":
+            # process_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+            pass
+
+        result = subprocess.run([exe_path], **process_kwargs)
+
+        assert result.returncode == 0, \
+            f"{RESRGAN_EXE_NAME} exited with {result.returncode}. Stderr: '{result.stderr}'. Stdout: '{result.stdout}'"
+
+        output_combined = result.stdout.lower() + result.stderr.lower()
+        assert "device" in output_combined, \
+            f"{RESRGAN_EXE_NAME} did not print device info. Combined Output: '{output_combined}'"
+
+    except FileNotFoundError:
+        assert False, f"{RESRGAN_EXE_NAME} could not be found to run. Path: {exe_path}"
+    except subprocess.TimeoutExpired:
+        assert False, f"{RESRGAN_EXE_NAME} timed out after {TIMEOUT_SECONDS} seconds."
+
+if __name__ == "__main__":
+    # This allows running the test directly using "python tests/test_upscaler_execution.py"
+    # For pytest, it will discover the test_ functions automatically.
+
+    print(f"Upscaler tests running. Expecting executables in: {os.path.abspath(APP_DIR)}")
+    print(f"Platform: {sys.platform}")
+
+    # Check if APP_DIR exists first, to give a clearer error if it doesn't.
+    if not os.path.isdir(APP_DIR):
+        print(f"ERROR: Application directory '{APP_DIR}' not found relative to current path '{os.getcwd()}'.")
+        print("Please ensure the tests are run from the repository root, and the application has been built.")
+        sys.exit(1)
+
+    print("\nRunning test_realcugan_executable_existence_and_run...")
+    try:
+        test_realcugan_executable_existence_and_run()
+        print("test_realcugan_executable_existence_and_run PASSED")
+    except AssertionError as e:
+        print(f"test_realcugan_executable_existence_and_run FAILED: {e}")
+    except Exception as e:
+        print(f"test_realcugan_executable_existence_and_run ERRORED: {e}")
+
+    print("\nRunning test_realesrgan_executable_existence_and_run...")
+    try:
+        test_realesrgan_executable_existence_and_run()
+        print("test_realesrgan_executable_existence_and_run PASSED")
+    except AssertionError as e:
+        print(f"test_realesrgan_executable_existence_and_run FAILED: {e}")
+    except Exception as e:
+        print(f"test_realesrgan_executable_existence_and_run ERRORED: {e}")
+
+    print("\nAll upscaler execution tests completed (check output for PASS/FAIL/ERROR).")


### PR DESCRIPTION
…compatibility and development:

1.  The `build_projects.sh` script now selectively copies only essential .exe and .dll files for prebuilt Windows upscaler binaries. It also implements a fallback to build these upscalers (Real-ESRGAN, Real-CUGAN) using CMake if the prebuilt directories are not found on a Windows system.

2.  The C++ source code in `Waifu2x-Extension-QT` has been refactored. Upscaler executables (`realcugan-ncnn-vulkan.exe`, `realesrgan-ncnn-vulkan.exe`) and RealCUGAN models are now located relative to the application's executable directory (`QCoreApplication::applicationDirPath()`). This replaces hardcoded paths and reliance on the current working directory, improving portability.

3.  A new integration test, `tests/test_upscaler_execution.py`, has been added. This test verifies that the upscaler executables are present in the expected location (`Waifu2x-Extension-QT/`) after the build and that they can be run successfully (checking exit code and basic output).

These changes aim to make the build process more robust on Windows, ensure the application correctly finds its dependencies, and facilitate easier development in virtual or isolated environments.