### PR TITLE
Add Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,37 @@ jobs:
           cat cppcheck.log
       - name: Run tests
         run: pytest
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          modules: 'qtbase qtshadertools'
+      - name: Install build tools
+        run: |
+          choco install make cmake -y
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Build projects
+        shell: bash
+        run: |
+          ./build_projects.sh > build.log 2>&1
+      - name: Run tests
+        shell: bash
+        run: |
+          pytest > pytest.log 2>&1
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-test-logs
+          path: |
+            build.log
+            pytest.log


### PR DESCRIPTION
## Summary
- run CI on Windows as well
- install Qt and build tools
- invoke `build_projects.sh` then run tests on Windows
- upload Windows build logs as artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0f2e4f408322bcefebd9eab1124f