### PR TITLE
CI: store Windows pytest logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,12 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          pytest > pytest.log 2>&1
+          pytest --junitxml tests/windows-test.xml > tests/windows-test.log 2>&1
       - name: Upload test logs
         uses: actions/upload-artifact@v4
         with:
           name: windows-test-logs
           path: |
             build.log
-            pytest.log
+            tests/windows-test.log
+            tests/windows-test.xml

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ The sample images used for testing are located under
 `realcugan-ncnn-vulkan/images/` and in the
 `realesrgan-ncnn-vulkan/windows` folder.
 
+During CI the Windows workflow captures the pytest output into
+`tests/windows-test.log` and uploads it as the **windows-test-logs** artifact.
+The log can be downloaded from the workflow run's "Artifacts" section.
+
 ## Static Analysis
 [![cppcheck](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml/badge.svg)](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml)
 


### PR DESCRIPTION
## Summary
- capture Windows test output to `tests/windows-test.log`
- upload log file and junit report as workflow artifacts
- explain where to download Windows logs in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e11335a2c83228ac94875bb9385d3