### PR TITLE
Improve static analysis script error checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The log can be downloaded from the workflow run's "Artifacts" section.
 ## Static Analysis
 [![cppcheck](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml/badge.svg)](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml)
 
-Static analysis can be performed with [cppcheck](https://cppcheck.sourceforge.io/). The helper script expects the Qt development headers, `cppcheck` itself and `pkg-config` to be present. On Debian-based distributions install them with:
+Static analysis can be performed with [cppcheck](https://cppcheck.sourceforge.io/). The helper script expects `cppcheck`, `pkg-config` and the Qt development headers to be present. If `pkg-config` cannot locate Qt, install the development package providing the Qt pkg-config files (e.g., `qtbase5-dev` or `qtbase6-dev`). On Debian-based distributions install them with:
 
 ```bash
 sudo apt-get update

--- a/tools/run_cppcheck.sh
+++ b/tools/run_cppcheck.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
 set -e
-QT_INCLUDE_DIR=$(pkg-config --variable=includedir Qt5Core)
- cppcheck --enable=all --library=qt --template=gcc --force --std=c++11 \
-         @tools/cppcheck.cfg \
-         -I "$QT_INCLUDE_DIR" \
-         -I "$QT_INCLUDE_DIR/QtCore" \
-         -I "$QT_INCLUDE_DIR/QtGui" \
-         -I "$QT_INCLUDE_DIR/QtWidgets" \
-          -I "/usr/include" \
-         Waifu2x-Extension-QT 2> cppcheck.log
+
+if ! command -v pkg-config >/dev/null; then
+    echo "Error: pkg-config not found. Install pkg-config to run static analysis." >&2
+    exit 1
+fi
+
+QT_PKG=""
+if pkg-config --exists Qt5Core; then
+    QT_PKG=Qt5Core
+elif pkg-config --exists Qt6Core; then
+    QT_PKG=Qt6Core
+else
+    echo "Error: Qt development packages not found. Install qtbase5-dev or qtbase6-dev." >&2
+    exit 1
+fi
+
+QT_INCLUDE_DIR=$(pkg-config --variable=includedir "$QT_PKG")
+
+cppcheck --enable=all --library=qt --template=gcc --force --std=c++11 \
+    @tools/cppcheck.cfg \
+    -I "$QT_INCLUDE_DIR" \
+    -I "$QT_INCLUDE_DIR/QtCore" \
+    -I "$QT_INCLUDE_DIR/QtGui" \
+    -I "$QT_INCLUDE_DIR/QtWidgets" \
+    -I "/usr/include" \
+    Waifu2x-Extension-QT 2> cppcheck.log


### PR DESCRIPTION
## Summary
- check for missing pkg-config or Qt dev packages when running cppcheck
- document the Qt dev package requirement in README

## Testing
- `pip install -r requirements.txt`
- `sudo apt-get install -y libegl1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3e38ad3483229a9422fe81447c9a