### PR TITLE
Fix msys path conversion

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -250,7 +250,7 @@ function Build-Project {
     }
 
     $currentDir = (Get-Location).Path
-    $msysDir = ($currentDir -replace '\\', '/')
+    $msysDir = (($currentDir -replace '^([A-Za-z]):', '/$1') -replace '\\', '/')
     
     # Define paths to the necessary bin directories for the build environment
     $mingwBinPath = 'C:\tools\msys64\mingw64\bin'


### PR DESCRIPTION
## Summary
- handle drive letter conversion in build_windows.ps1 so MSYS paths work from directories containing spaces

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684e4fe94c4c83228bc60fc396b749c9