### PR TITLE
Improve Windows build path logic

### DIFF
--- a/build_projects.sh
+++ b/build_projects.sh
@@ -23,7 +23,13 @@ case $(uname -s | tr '[:upper:]' '[:lower:]') in
         echo "Windows environment detected. Handling upscaler binaries..."
 
         # Attempt to add Vulkan SDK to PATH for glslc
-        VULKAN_SDK_BIN_PATH="/c/VulkanSDK/$(ls /c/VulkanSDK/)/Bin" # Adjust if Vulkan SDK version directory varies
+        VULKAN_SDK_BIN_PATH=""
+        for d in /c/VulkanSDK/*; do
+            if [ -d "$d/Bin" ]; then
+                VULKAN_SDK_BIN_PATH="$d/Bin"
+                break
+            fi
+        done
         if [ -d "$VULKAN_SDK_BIN_PATH" ] && [ -f "$VULKAN_SDK_BIN_PATH/glslc.exe" ]; then
             echo "Found glslc in Vulkan SDK at $VULKAN_SDK_BIN_PATH. Adding to PATH."
             export PATH="$VULKAN_SDK_BIN_PATH:$PATH"

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -76,8 +76,9 @@ function Convert-PathToMsys {
 
     if ($Path -match '^([A-Za-z]):') {
         $drive = $matches[1].ToLower()
+        return "/$drive" + ($Path.Substring(2) -replace '\\', '/')
     }
-    return "/$drive" + ($Path.Substring(2) -replace '\\', '/')
+    return ($Path -replace '\\', '/')
 }
 
 # Finds the MSYS2 bash executable.


### PR DESCRIPTION
## Summary
- fix path conversion for non-drive paths
- remove `ls` dependency when detecting the Vulkan SDK

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6921c89083229f34e0139faf600f