### PR TITLE
Fix: Correct bash path detection in Windows build script

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -347,8 +347,8 @@ try {
     # Ensure-ChocoPackage 'vulkan-sdk'
     
     # Find MSYS2 after ensuring it's installed.
-    # $bashPath = Find-Msys2Bash
-    $bashPath = '/bin/bash' # Provide a dummy path
+    $bashPath = Find-Msys2Bash
+    # $bashPath = '/bin/bash' # Provide a dummy path
 
     # Step 2: Set up the MSYS2 environment.
     # Install-MSYS2Packages -Msys2BashPath $bashPath


### PR DESCRIPTION
The `build_windows.ps1` script was previously hardcoded to use `/bin/bash`, which is not a standard path on Windows systems and caused build failures.

This change modifies the script to use the `Find-Msys2Bash` function, which was already present but commented out. This function dynamically locates the `bash.exe` executable provided by an MSYS2 installation, ensuring the script can find and use the correct bash environment.

This resolves the "Cannot find executable: '/bin/bash'" error encountered during the build process on Windows.