### PR TITLE
Fix QtDir resolution for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ powershell -ExecutionPolicy Bypass -File .\build_windows.ps1
 The script requires administrator privileges because it installs packages via
 Chocolatey. It will fetch Qt through `aqtinstall` if `qmake` is not available
 and ensures the **qtshadertools** module is present for the Liquid Glass shader.
+If you customize the `-QtDir` argument, supply an absolute Windows path so the
+script can correctly locate Qt.
 
 ## Development Environment
 

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -206,6 +206,7 @@ function Ensure-QMake {
     if (-not (Test-Path $QtDir)) {
         New-Item -ItemType Directory -Path $QtDir | Out-Null
     }
+    $QtDir = (Resolve-Path $QtDir).Path
 
     $qtModules = @('qtmultimedia', 'qtshadertools')
     $qtInstallArgs = @(


### PR DESCRIPTION
## Summary
- resolve `QtDir` to an absolute path inside `build_windows.ps1`
- document that `-QtDir` must be an absolute Windows path when customized

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684e6f2d585c83228077424e419533fd