### PR TITLE
Update path conversion for MSYS

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -78,6 +78,12 @@ function Convert-PathToMsys {
         $drive = $matches[1].ToLower()
         return "/$drive" + ($Path.Substring(2) -replace '\\', '/')
     }
+
+    if ($Path -match '^\\(?!\\)') {
+        $drive = (Get-Location).Drive.Name.TrimEnd(':').ToLower()
+        return "/$drive" + ($Path -replace '\\', '/')
+    }
+
     return ($Path -replace '\\', '/')
 }
 

--- a/tests/test_convert_path.ps1
+++ b/tests/test_convert_path.ps1
@@ -1,0 +1,34 @@
+BeforeAll {
+    function Convert-PathToMsys {
+        param(
+            [string]$Path
+        )
+
+        if ($Path -match '^([A-Za-z]):') {
+            $drive = $matches[1].ToLower()
+            return "/$drive" + ($Path.Substring(2) -replace '\\', '/')
+        }
+
+        if ($Path -match '^\\(?!\\)') {
+            $drive = (Get-Location).Drive.Name.TrimEnd(':').ToLower()
+            return "/$drive" + ($Path -replace '\\', '/')
+        }
+
+        return ($Path -replace '\\', '/')
+    }
+}
+
+Describe "Convert-PathToMsys" {
+    It "converts drive-letter paths" {
+        Convert-PathToMsys 'C:\tmp\Qt' | Should -Be '/c/tmp/Qt'
+    }
+
+    It "converts root-relative paths using current drive" {
+        $drive = (Get-Location).Drive.Name.TrimEnd(':').ToLower()
+        Convert-PathToMsys '\tmp\Qt' | Should -Be "/$drive/tmp/Qt"
+    }
+
+    It "returns POSIX paths unchanged" {
+        Convert-PathToMsys '/c/tmp/Qt' | Should -Be '/c/tmp/Qt'
+    }
+}


### PR DESCRIPTION
## Summary
- improve `Convert-PathToMsys` to resolve root-relative paths
- test drive-letter, root-relative and POSIX paths using Pester

## Testing
- `pwsh -Command 'Invoke-Pester -Script tests/test_convert_path.ps1 -Passthru'`
- `pytest -q` *(fails: ModuleNotFoundError for PIL and PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_684e728fa8608322b50a5d95c20a35c1