### PR TITLE
Improve Qt build checks

### DIFF
--- a/tests/test_build_projects_windows.py
+++ b/tests/test_build_projects_windows.py
@@ -18,7 +18,7 @@ def run_build(tmp_path: Path, uname_output: str, make_cmd: str = 'make') -> None
     (tmp_path / 'realcugan-ncnn-vulkan' / 'windows' / 'realcugan.dll').write_text('')
     bin_dir = tmp_path / 'bin'
     bin_dir.mkdir()
-    for name in ('qmake', make_cmd, 'cmake'):
+    for name in ('qmake', make_cmd, 'cmake', 'qsb'):
         f = bin_dir / name
         f.write_text('#!/bin/sh\nexit 0\n')
         f.chmod(0o755)


### PR DESCRIPTION
## Summary
- validate Qt tools in `build_projects.sh`
- run `make liquidglass_frag` before the main build
- update Windows build tests for qsb stub

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7ac0bdc88322b31f4cbcd3ac1b0e