### PR TITLE
Fix shader build command

### DIFF
--- a/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
+++ b/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
@@ -108,8 +108,9 @@ RESOURCES += \
 liquidglass_frag.input = SHADER
 liquidglass_frag.files = $$PWD/shaders/liquidglass.frag
 liquidglass_frag.output = $$OUT_PWD/shaders/liquidglass.frag.qsb
-liquidglass_frag.commands = mkdir -p $$OUT_PWD/shaders && \
-    $$[QT_HOST_BINS]/qsb ${QMAKE_FILE_NAME} -o ${QMAKE_FILE_OUT}
+liquidglass_frag.commands = \
+    mkdir -p $$OUT_PWD/shaders && \
+    $$[QT_HOST_BINS]/qsb $$PWD/shaders/liquidglass.frag -o $$OUT_PWD/shaders/liquidglass.frag.qsb
 liquidglass_frag.CONFIG = no_link
 QMAKE_EXTRA_TARGETS += liquidglass_frag
 PRE_TARGETDEPS += $$liquidglass_frag.output


### PR DESCRIPTION
## Summary
- fix shader compilation command in the project file

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e7c9130548322ba5f8502a63adb2c