### PR TITLE
Fix openFile path escaping

### DIFF
--- a/Waifu2x-Extension-QT/FileManager.cpp
+++ b/Waifu2x-Extension-QT/FileManager.cpp
@@ -187,15 +187,18 @@ bool FileManager::openFile(const QString &filePath)
 {
     if (QFile::exists(filePath))
     {
+        QString path = filePath;
 #ifdef Q_OS_WIN
-        if (!QDesktopServices::openUrl(QUrl("file:" + QUrl::toPercentEncoding(filePath), QUrl::TolerantMode)))
+        if (!QDesktopServices::openUrl(
+                QUrl("file:" + QUrl::toPercentEncoding(path), QUrl::TolerantMode)))
         {
-            QProcess::execute("start \"\" \"" + filePath.replace('%', "%%") + "\"");
+            path.replace('%', "%%");
+            QProcess::execute("start \"\" \"" + path + "\"");
         }
 #else
-        if (!QDesktopServices::openUrl(QUrl::fromLocalFile(filePath)))
+        if (!QDesktopServices::openUrl(QUrl::fromLocalFile(path)))
         {
-            QProcess::execute("xdg-open", QStringList() << filePath);
+            QProcess::execute("xdg-open", QStringList() << path);
         }
 #endif
         return true;

--- a/Waifu2x-Extension-QT/FileManager.h
+++ b/Waifu2x-Extension-QT/FileManager.h
@@ -28,6 +28,12 @@ public:
     bool isDirWritable(const QString &dirPath);
     bool openFolder(const QString &folderPath);
     bool openFilesFolder(const QString &filePath);
+
+    /**
+     * @brief Open the given file using the system's default application.
+     * @param filePath Path to the file.
+     * @return True if the launch command was issued.
+     */
     bool openFile(const QString &filePath);
     bool generateMarkFile(const QString &fileFullPath, const QString &msg);
 


### PR DESCRIPTION
## Summary
- escape Windows paths in `FileManager::openFile`
- document the public method `openFile`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7f83fbe88322a2042de709aa6b69