### PR TITLE
Switch to Qt5 compat QTextCodec

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -24,7 +24,7 @@
 #include <QtGlobal>
 #include <QListWidgetItem>
 #include <QDebug>
-#include <QTextCodec>
+#include <QtCore5Compat/QTextCodec>
 
 RealCuganProcessor::RealCuganProcessor(MainWindow *parent)
     : QObject(parent), m_mainWindow(parent)

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -49,7 +49,7 @@ Copyright (C) 2025  beyawnko
 #include <QScreen>
 #include <QCloseEvent>
 #include <QFileDialog>
-#include <QTextCodec>
+#include <QtCore5Compat/QTextCodec>
 #include <math.h>
 #include <QMutex>
 #include <QSystemTrayIcon>

--- a/Waifu2x-Extension-QT/topsupporterslist.h
+++ b/Waifu2x-Extension-QT/topsupporterslist.h
@@ -25,7 +25,7 @@
 #include <QWidget>
 #include <QSettings>
 #include <QFile>
-#include <QTextCodec>
+#include <QtCore5Compat/QTextCodec>
 #include <QDesktopServices>
 
 namespace Ui


### PR DESCRIPTION
## Summary
- use `QtCore5Compat/QTextCodec` in several headers and source files
- confirm `core5compat` is part of QT modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e807d66008322950d51cc7829cddc