### PR TITLE
Fix Qt module list

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -214,7 +214,7 @@ function Ensure-QMake {
     }
     $QtDir = (Resolve-Path $QtDir).Path
 
-    $qtModules = @('qtmultimedia', 'qtshadertools')
+    $qtModules = @('qtmultimedia', 'qtshadertools', 'qt5compat')
     $qtInstallArgs = @(
         '-m', 'aqt',
         'install-qt', 'windows', 'desktop', $QtVersion, 'win64_mingw',


### PR DESCRIPTION
## Summary
- include `qt5compat` in the Qt module list for the Windows build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8491aa048322910dc4ebdd11fcbd