### PR TITLE
Fix header dependency for RealcuganJobManager

### DIFF
--- a/Waifu2x-Extension-QT/RealcuganJobManager.cpp
+++ b/Waifu2x-Extension-QT/RealcuganJobManager.cpp
@@ -22,7 +22,7 @@ RealcuganJobManager::RealcuganJobManager(QObject *parent)
 {}
 
 QString RealcuganJobManager::buildGpuJobString(bool multiGpuEnabled,
-                                              const QList_QMap_QStrQStr &gpuList,
+                                              const QList<QMap<QString, QString>> &gpuList,
                                               const QString &fallbackGpuId) const
 {
     if (multiGpuEnabled) {

--- a/Waifu2x-Extension-QT/RealcuganJobManager.h
+++ b/Waifu2x-Extension-QT/RealcuganJobManager.h
@@ -19,7 +19,8 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
-#include "mainwindow.h"
+#include <QList>
+#include <QMap>
 
 /**
  * @brief Manage GPU job configuration for RealCUGAN tasks.
@@ -38,7 +39,7 @@ public:
      * @return Command arguments for GPU job configuration.
      */
     QString buildGpuJobString(bool multiGpuEnabled,
-                              const QList_QMap_QStrQStr &gpuList,
+                              const QList<QMap<QString, QString>> &gpuList,
                               const QString &fallbackGpuId) const;
 };
 


### PR DESCRIPTION
## Summary
- remove `mainwindow.h` include from `RealcuganJobManager.h`
- add explicit Qt container includes and update function signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1738306883228ae6c0be322dce10