### PR TITLE
Store QtConcurrent future in CompatibilityTest

### DIFF
--- a/Waifu2x-Extension-QT/CompatibilityTest.cpp
+++ b/Waifu2x-Extension-QT/CompatibilityTest.cpp
@@ -4,7 +4,9 @@
 void MainWindow::on_pushButton_compatibilityTest_clicked()
 {
     ui->pushButton_compatibilityTest->setEnabled(false);
-    QtConcurrent::run([this]() { this->Simple_Compatibility_Test(); });
+    compatibilityTestFuture = QtConcurrent::run([this]() {
+        this->Simple_Compatibility_Test();
+    });
 }
 
 int MainWindow::Simple_Compatibility_Test()
@@ -15,4 +17,12 @@ int MainWindow::Simple_Compatibility_Test()
     isCompatible_RealESRGAN_NCNN_Vulkan = QFile::exists(realesrganExe);
     emit Send_Waifu2x_Compatibility_Test_finished();
     return 0;
+}
+
+void MainWindow::waitForCompatibilityTest()
+{
+    if (compatibilityTestFuture.isRunning())
+    {
+        compatibilityTestFuture.waitForFinished();
+    }
 }

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -334,6 +334,7 @@ public:
     //================================================================
     int Waifu2x_Compatibility_Test();// engine compatibility check
     int Simple_Compatibility_Test(); // Public member function
+    void waitForCompatibilityTest(); // Wait for compatibility test to finish
     // initialize compatibility test progress bar
     void Init_progressBar_CompatibilityTest();
     // operations after compatibility test finished
@@ -632,6 +633,7 @@ public:
     QFuture<int> AutoUpdate;// monitor auto update thread
     QFuture<int> DownloadOnlineQRCode;// monitor online QR code download
     QFuture<int> Waifu2xMain;// monitor main waifu2x thread
+    QFuture<void> compatibilityTestFuture; // monitor compatibility test thread
     int Force_close();// forcibly close using cmd
     std::atomic<bool> isAlreadyClosed{false};
 


### PR DESCRIPTION
## Summary
- return QtConcurrent::run value in a `QFuture<void>` for `CompatibilityTest`
- allow waiting for the test to finish via `waitForCompatibilityTest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2cbfdf308322bba79fc0e1d6d160