### PR TITLE
Apply fixes to RealCUGAN utilities and header

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -3538,6 +3538,11 @@ int MainWindow::SRMD_CUDA_Video(int){return 0;}
 int MainWindow::SRMD_CUDA_Video_BySegment(int){return 0;}
 // ... (The rest of the functions from the original file) ...
 
+void MainWindow::ShellMessageBox(const QString &title, const QString &text, QMessageBox::Icon icon)
+{
+    QMessageBox msg(icon, title, text, QMessageBox::Ok, this);
+    msg.exec();
+}
 
 bool MainWindow::runProcess(QProcess *process, const QString &cmd,
                             QByteArray *stdOut, QByteArray *stdErr)

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -425,7 +425,7 @@ public:
     void Realcugan_NCNN_Vulkan_Video_BySegment(int rowNum);
     void Realcugan_NCNN_Vulkan_ReadSettings();
     void Realcugan_NCNN_Vulkan_ReadSettings_Video_GIF(int ThreadNum);
-    bool APNG_RealcuganNCNNVulkan(
+    void APNG_RealcuganNCNNVulkan(
         QString splitFramesFolder,
         QString scaledFramesFolder,
         QString sourceFileFullPath,
@@ -459,6 +459,8 @@ public:
         const QString &inputFile,
         const QString &outputFile,
         int targetScale,
+        int originalWidth,
+        int originalHeight,
         const QString &modelName,
         int denoiseLevel,
         int tileSize,

--- a/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
@@ -30,6 +30,12 @@
 #include <QRegularExpression>
 #include <QDirIterator>
 
+static int StartedProc = 0;
+static int NumProc = 0;
+static int FinishedProc = 0;
+static int ErrorProc = 0;
+static int TotalNumProc = 0;
+
 // Utility to warn when an external process fails
 static bool warnProcessFailure(QWidget *parent, QProcess &proc,
                                const QString &context)
@@ -1866,7 +1872,7 @@ void MainWindow::AddGPU_MultiGPU_RealcuganNcnnVulkan(QString GPUID_Name)
 
     for (const auto& map : GPUIDs_List_MultiGPU_RealCUGAN) {
         if (map.value("ID") == selectedGPU_ID_str) {
-            ShowMessageBox("Info", "This GPU has already been added for RealCUGAN.", QMessageBox::Information);
+            ShellMessageBox(tr("Info"), tr("This GPU has already been added for RealCUGAN."), QMessageBox::Information);
             return;
         }
     }
@@ -2007,7 +2013,7 @@ void MainWindow::on_pushButton_AddGPU_MultiGPU_RealCUGAN_clicked()
 {
     QString selectedGPU_Text = comboBox_GPUIDs_MultiGPU_RealCUGAN->currentText();
     if (selectedGPU_Text.isEmpty() || selectedGPU_Text.contains("Default GPU (Detection Failed)") || selectedGPU_Text.contains("No available")) {
-        ShowMessageBox("Info", "Please select a valid GPU to add for RealCUGAN.", QMessageBox::Information);
+        ShellMessageBox(tr("Info"), tr("Please select a valid GPU to add for RealCUGAN."), QMessageBox::Information);
         return;
     }
     AddGPU_MultiGPU_RealcuganNcnnVulkan(selectedGPU_Text);
@@ -2017,7 +2023,7 @@ void MainWindow::on_pushButton_RemoveGPU_MultiGPU_RealCUGAN_clicked()
 {
     QListWidgetItem *selectedItem = listWidget_GPUList_MultiGPU_RealCUGAN->currentItem();
     if (!selectedItem) {
-        ShowMessageBox("Info", "Please select a GPU from the list to remove.", QMessageBox::Information);
+        ShellMessageBox(tr("Info"), tr("Please select a GPU from the list to remove."), QMessageBox::Information);
         return;
     }
 


### PR DESCRIPTION
## Summary
- correct the RealCUGAN function declarations in `mainwindow.h`
- add missing process counters in `realcugan_ncnn_vulkan.cpp`
- add `ShellMessageBox` helper in `mainwindow.cpp`
- replace obsolete `ShowMessageBox` calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `./build_projects.sh` *(fails: qmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3d7ed2d8832282f162ac7ddf46c5