### PR TITLE
Add missing iterative readyRead slot declarations

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -735,6 +735,8 @@ public slots: // Changed from 'slots:' for clarity, Qt treats them as public slo
     void on_pushButton_TileSize_Minus_RealCUGAN_clicked();
     void on_comboBox_Model_RealCUGAN_currentIndexChanged(int index);
     void Realcugan_NCNN_Vulkan_Iterative_finished(int exitCode, QProcess::ExitStatus exitStatus);
+    void Realcugan_NCNN_Vulkan_Iterative_readyReadStandardOutput();
+    void Realcugan_NCNN_Vulkan_Iterative_readyReadStandardError();
     void Realcugan_NCNN_Vulkan_Iterative_errorOccurred(QProcess::ProcessError error);
     void Realcugan_NCNN_Vulkan_DetectGPU_errorOccurred(QProcess::ProcessError error);
 
@@ -751,6 +753,8 @@ public slots: // Changed from 'slots:' for clarity, Qt treats them as public slo
     void RealESRGAN_NCNN_Vulkan_finished(int exitCode, QProcess::ExitStatus exitStatus);
     void RealESRGAN_NCNN_Vulkan_errorOccurred(QProcess::ProcessError error);
     void RealESRGAN_NCNN_Vulkan_Iterative_finished(int exitCode, QProcess::ExitStatus exitStatus);
+    void RealESRGAN_NCNN_Vulkan_Iterative_readyReadStandardOutput();
+    void RealESRGAN_NCNN_Vulkan_Iterative_readyReadStandardError();
     void RealESRGAN_NCNN_Vulkan_Iterative_errorOccurred(QProcess::ProcessError error);
     void RealESRGAN_NCNN_Vulkan_DetectGPU_errorOccurred(QProcess::ProcessError error);
 


### PR DESCRIPTION
## Summary
- declare iterative readyRead slots for RealCUGAN and RealESRGAN
- attempt to rebuild project

## Testing
- `bash simple_build.sh` *(fails: Unknown module(s) in QT)*
- `make -j4` *(fails: missing declarations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684f60ba15288322a4d5e3e8dffe86c2