### PR TITLE
Fix Qt5 ini codec usage

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -28,6 +28,9 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QSettings>
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#include <QTextCodec>
+#endif
 #include <QFile>
 #include <QPalette>
 #include <QColor>
@@ -2647,7 +2650,9 @@ void MainWindow::APNG_Main(int rowNum, bool isFromImageList)
 int MainWindow::Table_Save_Current_Table_Filelist(QString Table_FileList_ini)
 {
     QSettings *configIniWrite = new QSettings(Table_FileList_ini, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniWrite->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     configIniWrite->setValue("/Warning/EN", "Do not modify this file! It may cause the program to crash! If problems occur after the modification, delete this file and restart the program.");
     configIniWrite->setValue("/Warning/CN", tr("Please do not modify this file, otherwise it may cause the program to crash! If problems occur after modification, please delete this file and restart the program.")); // Please do not modify this file, otherwise it may cause the program to crash! If problems occur after modification, please delete this file and restart the program.
 
@@ -2710,7 +2715,9 @@ int MainWindow::Table_Save_Current_Table_Filelist(QString Table_FileList_ini)
 int MainWindow::Table_Read_Saved_Table_Filelist(QString Table_FileList_ini)
 {
     QSettings *configIniRead = new QSettings(Table_FileList_ini, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniRead->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
 
     int rowCount_image = configIniRead->value("/numOfimage").toInt();
     for(int i=0;i<rowCount_image;i++)

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -20,6 +20,9 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "UiController.h"
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#include <QTextCodec>
+#endif
 
 /*
 Save settings
@@ -31,7 +34,9 @@ int MainWindow::Settings_Save()
     QFile::remove(settings_ini);
     //=================
     QSettings *configIniWrite = new QSettings(settings_ini, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniWrite->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     //================= Add warning =========================
     configIniWrite->setValue("/Warning/.", "Do not modify this file! It may cause the program to crash! If problems occur after the modification, delete this file and restart the program.");
     //==================== Save version identifier ==================================
@@ -288,7 +293,9 @@ int MainWindow::Settings_Read_Apply()
     else
     {
         QSettings *configIniRead_ver = new QSettings(settings_ini, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         configIniRead_ver->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
         QString Settings_VERSION = configIniRead_ver->value("/settings/VERSION").toString();
         if(Settings_VERSION!=VERSION)
         {
@@ -302,7 +309,9 @@ int MainWindow::Settings_Read_Apply()
     }
     //=================
     QSettings *configIniRead = new QSettings(settings_ini, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniRead->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     //=================== Load global font settings =========================
     ui->spinBox_GlobalFontSize->setValue(Settings_Read_value("/settings/GlobalFontSize").toInt());
     ui->fontComboBox_CustFont->setCurrentFont(Settings_Read_value("/settings/CustFont").value<QFont>());
@@ -691,12 +700,16 @@ QVariant MainWindow::Settings_Read_value(QString Key)
     QString settings_ini_old = Current_Path+"/settings_old.ini";
     QString settings_ini_new = Current_Path+"/settings.ini";
     QSettings *configIniRead_new = new QSettings(settings_ini_new, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniRead_new->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     //====
     if(isReadOldSettings&&QFile::exists(settings_ini_old))
     {
         QSettings *configIniRead_old = new QSettings(settings_ini_old, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         configIniRead_old->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
         //====
         if(configIniRead_old->contains(Key))
         {

--- a/Waifu2x-Extension-QT/topsupporterslist.cpp
+++ b/Waifu2x-Extension-QT/topsupporterslist.cpp
@@ -19,6 +19,9 @@
 
 #include "topsupporterslist.h"
 #include "ui_topsupporterslist.h"
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#include <QTextCodec>
+#endif
 
 TopSupportersList::TopSupportersList(QWidget *parent) :
     QWidget(parent),
@@ -36,7 +39,9 @@ TopSupportersList::TopSupportersList(QWidget *parent) :
     if(QFile::exists(TopSupportersList_ini_path) == true)
     {
         QSettings *configIniRead = new QSettings(TopSupportersList_ini_path, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         configIniRead->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
         QString Change_log = configIniRead->value("/TopSupportersList/List").toString();
         if(configIniRead->value("/TopSupportersList/List") != QVariant() && Change_log.trimmed()!="")
         {

--- a/Waifu2x-Extension-QT/video.cpp
+++ b/Waifu2x-Extension-QT/video.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+    Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -16,6 +16,9 @@
 
     My Github homepage: https://github.com/AaronFeng753
 */
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#include <QTextCodec>
+#endif
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "utils/ffprobe_helpers.h"
@@ -566,7 +569,9 @@ Save progress
 void MainWindow::video_write_Progress_ProcessBySegment(QString VideoConfiguration_fullPath,int StartTime,bool isSplitComplete,bool isScaleComplete,int OLDSegmentDuration,int LastVideoClipNo)
 {
     QSettings *configIniWrite = new QSettings(VideoConfiguration_fullPath, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniWrite->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     //==================== Store progress ==================================
     configIniWrite->setValue("/Progress/StartTime", StartTime);
     configIniWrite->setValue("/Progress/isSplitComplete", isSplitComplete);
@@ -580,7 +585,9 @@ Save video configuration
 void MainWindow::video_write_VideoConfiguration(QString VideoConfiguration_fullPath,int ScaleRatio,int DenoiseLevel,bool CustRes_isEnabled,int CustRes_height,int CustRes_width,QString EngineName,bool isProcessBySegment,QString VideoClipsFolderPath,QString VideoClipsFolderName,bool isVideoFrameInterpolationEnabled,int MultipleOfFPS)
 {
     QSettings *configIniWrite = new QSettings(VideoConfiguration_fullPath, QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     configIniWrite->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     //================= Add warning =========================
     configIniWrite->setValue("/Warning/EN", "Do not modify this file! It may cause the program to crash! If problems occur after the modification, delete this file and restart the program.");
     //==================== Store video information ==================================


### PR DESCRIPTION
## Summary
- avoid `setIniCodec` when building with Qt6
- update copyright
- keep UTF-8 handling under Qt6

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6364763c8322b55e953715525d7f