### PR TITLE
Fix missing widgets in UI placeholder

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -315,7 +315,7 @@ public:
     void Realcugan_NCNN_Vulkan_Video_BySegment(int rowNum);
     void Realcugan_NCNN_Vulkan_ReadSettings();
     void Realcugan_NCNN_Vulkan_ReadSettings_Video_GIF(int ThreadNum);
-    void APNG_RealcuganNCNNVulkan(QString splitFramesFolder, QString scaledFramesFolder, QString sourceFileFullPath, QStringList framesFileName_qStrList, QString resultFileFullPath);
+    bool APNG_RealcuganNCNNVulkan(QString splitFramesFolder, QString scaledFramesFolder, QString sourceFileFullPath, QStringList framesFileName_qStrList, QString resultFileFullPath);
     void Realcugan_ncnn_vulkan_DetectGPU();
     QString RealcuganNcnnVulkan_MultiGPU();
     void AddGPU_MultiGPU_RealcuganNcnnVulkan(QString GPUID);
@@ -554,6 +554,7 @@ public:
     long unsigned int ETA=0;
     int CheckUpadte_Auto();
     int Donate_DownloadOnlineQRCode();
+    void on_checkBox_BanGitee_clicked();
     bool isSettingsHide=false;
     bool isShowAnime4kWarning=true;
     void ConnectivityTest_RawGithubusercontentCom();
@@ -726,6 +727,8 @@ public slots: // Changed from 'slots:' for clarity, Qt treats them as public slo
     void CurrentFileProgress_WatchFolderFileNum_Textbrower(QString SourceFile_fullPath, QString FolderPath, int TotalFileNum);
     void Donate_ReplaceQRCode(QString QRCodePath);
     void Set_checkBox_DisableResize_gif_Checked();
+    void on_pushButton_Patreon_clicked();
+    void on_pushButton_SupportersList_clicked();
 
     // RealCUGAN Slots
     void on_pushButton_DetectGPU_RealCUGAN_clicked();

--- a/Waifu2x-Extension-QT/mainwindow.ui
+++ b/Waifu2x-Extension-QT/mainwindow.ui
@@ -11334,6 +11334,84 @@ padding:10px;
     <widget class="QTextBrowser" name="textBrowser_SupportersNameList"/>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkBox_custres_isAll"/>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="Ext_image"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_DelOriginal"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_ReplaceOriginalFile"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_OutPath_isEnabled"/>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea_outputPathSettings"/>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="lineEdit_outputPath"/>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_CurrentFile"/>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar_CurrentFile"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_FrameProgress_CurrentFile"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_TimeRemain_CurrentFile"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_TimeCost_CurrentFile"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_ETA_CurrentFile"/>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_compatibilityTest"/>
+   </item>
+   <item>
+    <widget class="QDoubleSpinBox" name="doubleSpinBox_ScaleRatio_gif"/>
+   </item>
+   <item>
+   <widget class="QSpinBox" name="spinBox_DenoiseLevel_gif"/>
+   </item>
+   <item>
+   <widget class="QComboBox" name="comboBox_Engine_GIF"/>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="spinBox_CustRes_height"/>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="spinBox_CustRes_width"/>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="spinBox_ThreadNum_video_internal"/>
+   </item>
+   <item>
+   <widget class="QSpinBox" name="spinBox_NumOfThreads_VFI"/>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="spinBox_ThreadNum_image"/>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="spinBox_ThreadNum_gif_internal"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_BanGitee"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_DonateQRCode"/>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tabWidget"/>
+   </item>
+   <item>
     <widget class="QTabWidget" name="tabWidget_FileType"/>
    </item>
   </layout>

--- a/captured_ui_mainwindow.h.txt
+++ b/captured_ui_mainwindow.h.txt
@@ -6,17 +6,22 @@
 ** WARNING! All changes made in this file will be lost when recompiling UI file!
 ********************************************************************************/
 
-#ifndef UI_MAINWINDOW_H
-#define UI_MAINWINDOW_H
+#ifndef CAPTURED_UI_MAINWINDOW_H
+#define CAPTURED_UI_MAINWINDOW_H
 
 #include <QtCore/QVariant>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QComboBox>
+#include <QtWidgets/QDoubleSpinBox>
+#include <QtWidgets/QGroupBox>
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
 #include <QtWidgets/QListWidget>
+#include <QtWidgets/QProgressBar>
 #include <QtWidgets/QPushButton>
+#include <QtWidgets/QScrollArea>
 #include <QtWidgets/QSpinBox>
 #include <QtWidgets/QTabWidget>
 #include <QtWidgets/QTableWidget>
@@ -66,6 +71,32 @@ public:
     QSpinBox *spinBox_TileSize_RealCUGAN;
     QTableWidget *tableWidget_Files;
     QTextBrowser *textBrowser_SupportersNameList;
+    QCheckBox *checkBox_custres_isAll;
+    QLineEdit *Ext_image;
+    QCheckBox *checkBox_DelOriginal;
+    QCheckBox *checkBox_ReplaceOriginalFile;
+    QCheckBox *checkBox_OutPath_isEnabled;
+    QScrollArea *scrollArea_outputPathSettings;
+    QLineEdit *lineEdit_outputPath;
+    QGroupBox *groupBox_CurrentFile;
+    QProgressBar *progressBar_CurrentFile;
+    QLabel *label_FrameProgress_CurrentFile;
+    QLabel *label_TimeRemain_CurrentFile;
+    QLabel *label_TimeCost_CurrentFile;
+    QLabel *label_ETA_CurrentFile;
+    QPushButton *pushButton_compatibilityTest;
+    QDoubleSpinBox *doubleSpinBox_ScaleRatio_gif;
+    QSpinBox *spinBox_DenoiseLevel_gif;
+    QComboBox *comboBox_Engine_GIF;
+    QSpinBox *spinBox_CustRes_height;
+    QSpinBox *spinBox_CustRes_width;
+    QSpinBox *spinBox_ThreadNum_video_internal;
+    QSpinBox *spinBox_NumOfThreads_VFI;
+    QSpinBox *spinBox_ThreadNum_image;
+    QSpinBox *spinBox_ThreadNum_gif_internal;
+    QCheckBox *checkBox_BanGitee;
+    QLabel *label_DonateQRCode;
+    QTabWidget *tabWidget;
     QTabWidget *tabWidget_FileType;
 
     void setupUi(QWidget *placeholderWidgets)
@@ -255,6 +286,136 @@ public:
 
         verticalLayout_placeholder->addWidget(textBrowser_SupportersNameList);
 
+        checkBox_custres_isAll = new QCheckBox(placeholderWidgets);
+        checkBox_custres_isAll->setObjectName("checkBox_custres_isAll");
+
+        verticalLayout_placeholder->addWidget(checkBox_custres_isAll);
+
+        Ext_image = new QLineEdit(placeholderWidgets);
+        Ext_image->setObjectName("Ext_image");
+
+        verticalLayout_placeholder->addWidget(Ext_image);
+
+        checkBox_DelOriginal = new QCheckBox(placeholderWidgets);
+        checkBox_DelOriginal->setObjectName("checkBox_DelOriginal");
+
+        verticalLayout_placeholder->addWidget(checkBox_DelOriginal);
+
+        checkBox_ReplaceOriginalFile = new QCheckBox(placeholderWidgets);
+        checkBox_ReplaceOriginalFile->setObjectName("checkBox_ReplaceOriginalFile");
+
+        verticalLayout_placeholder->addWidget(checkBox_ReplaceOriginalFile);
+
+        checkBox_OutPath_isEnabled = new QCheckBox(placeholderWidgets);
+        checkBox_OutPath_isEnabled->setObjectName("checkBox_OutPath_isEnabled");
+
+        verticalLayout_placeholder->addWidget(checkBox_OutPath_isEnabled);
+
+        scrollArea_outputPathSettings = new QScrollArea(placeholderWidgets);
+        scrollArea_outputPathSettings->setObjectName("scrollArea_outputPathSettings");
+
+        verticalLayout_placeholder->addWidget(scrollArea_outputPathSettings);
+
+        lineEdit_outputPath = new QLineEdit(placeholderWidgets);
+        lineEdit_outputPath->setObjectName("lineEdit_outputPath");
+
+        verticalLayout_placeholder->addWidget(lineEdit_outputPath);
+
+        groupBox_CurrentFile = new QGroupBox(placeholderWidgets);
+        groupBox_CurrentFile->setObjectName("groupBox_CurrentFile");
+
+        verticalLayout_placeholder->addWidget(groupBox_CurrentFile);
+
+        progressBar_CurrentFile = new QProgressBar(placeholderWidgets);
+        progressBar_CurrentFile->setObjectName("progressBar_CurrentFile");
+
+        verticalLayout_placeholder->addWidget(progressBar_CurrentFile);
+
+        label_FrameProgress_CurrentFile = new QLabel(placeholderWidgets);
+        label_FrameProgress_CurrentFile->setObjectName("label_FrameProgress_CurrentFile");
+
+        verticalLayout_placeholder->addWidget(label_FrameProgress_CurrentFile);
+
+        label_TimeRemain_CurrentFile = new QLabel(placeholderWidgets);
+        label_TimeRemain_CurrentFile->setObjectName("label_TimeRemain_CurrentFile");
+
+        verticalLayout_placeholder->addWidget(label_TimeRemain_CurrentFile);
+
+        label_TimeCost_CurrentFile = new QLabel(placeholderWidgets);
+        label_TimeCost_CurrentFile->setObjectName("label_TimeCost_CurrentFile");
+
+        verticalLayout_placeholder->addWidget(label_TimeCost_CurrentFile);
+
+        label_ETA_CurrentFile = new QLabel(placeholderWidgets);
+        label_ETA_CurrentFile->setObjectName("label_ETA_CurrentFile");
+
+        verticalLayout_placeholder->addWidget(label_ETA_CurrentFile);
+
+        pushButton_compatibilityTest = new QPushButton(placeholderWidgets);
+        pushButton_compatibilityTest->setObjectName("pushButton_compatibilityTest");
+
+        verticalLayout_placeholder->addWidget(pushButton_compatibilityTest);
+
+        doubleSpinBox_ScaleRatio_gif = new QDoubleSpinBox(placeholderWidgets);
+        doubleSpinBox_ScaleRatio_gif->setObjectName("doubleSpinBox_ScaleRatio_gif");
+
+        verticalLayout_placeholder->addWidget(doubleSpinBox_ScaleRatio_gif);
+
+        spinBox_DenoiseLevel_gif = new QSpinBox(placeholderWidgets);
+        spinBox_DenoiseLevel_gif->setObjectName("spinBox_DenoiseLevel_gif");
+
+        verticalLayout_placeholder->addWidget(spinBox_DenoiseLevel_gif);
+
+        comboBox_Engine_GIF = new QComboBox(placeholderWidgets);
+        comboBox_Engine_GIF->setObjectName("comboBox_Engine_GIF");
+
+        verticalLayout_placeholder->addWidget(comboBox_Engine_GIF);
+
+        spinBox_CustRes_height = new QSpinBox(placeholderWidgets);
+        spinBox_CustRes_height->setObjectName("spinBox_CustRes_height");
+
+        verticalLayout_placeholder->addWidget(spinBox_CustRes_height);
+
+        spinBox_CustRes_width = new QSpinBox(placeholderWidgets);
+        spinBox_CustRes_width->setObjectName("spinBox_CustRes_width");
+
+        verticalLayout_placeholder->addWidget(spinBox_CustRes_width);
+
+        spinBox_ThreadNum_video_internal = new QSpinBox(placeholderWidgets);
+        spinBox_ThreadNum_video_internal->setObjectName("spinBox_ThreadNum_video_internal");
+
+        verticalLayout_placeholder->addWidget(spinBox_ThreadNum_video_internal);
+
+        spinBox_NumOfThreads_VFI = new QSpinBox(placeholderWidgets);
+        spinBox_NumOfThreads_VFI->setObjectName("spinBox_NumOfThreads_VFI");
+
+        verticalLayout_placeholder->addWidget(spinBox_NumOfThreads_VFI);
+
+        spinBox_ThreadNum_image = new QSpinBox(placeholderWidgets);
+        spinBox_ThreadNum_image->setObjectName("spinBox_ThreadNum_image");
+
+        verticalLayout_placeholder->addWidget(spinBox_ThreadNum_image);
+
+        spinBox_ThreadNum_gif_internal = new QSpinBox(placeholderWidgets);
+        spinBox_ThreadNum_gif_internal->setObjectName("spinBox_ThreadNum_gif_internal");
+
+        verticalLayout_placeholder->addWidget(spinBox_ThreadNum_gif_internal);
+
+        checkBox_BanGitee = new QCheckBox(placeholderWidgets);
+        checkBox_BanGitee->setObjectName("checkBox_BanGitee");
+
+        verticalLayout_placeholder->addWidget(checkBox_BanGitee);
+
+        label_DonateQRCode = new QLabel(placeholderWidgets);
+        label_DonateQRCode->setObjectName("label_DonateQRCode");
+
+        verticalLayout_placeholder->addWidget(label_DonateQRCode);
+
+        tabWidget = new QTabWidget(placeholderWidgets);
+        tabWidget->setObjectName("tabWidget");
+
+        verticalLayout_placeholder->addWidget(tabWidget);
+
         tabWidget_FileType = new QTabWidget(placeholderWidgets);
         tabWidget_FileType->setObjectName("tabWidget_FileType");
 
@@ -279,4 +440,4 @@ namespace Ui {
 
 QT_END_NAMESPACE
 
-#endif // UI_MAINWINDOW_H
+#endif // CAPTURED_UI_MAINWINDOW_H


### PR DESCRIPTION
## Summary
- update `mainwindow.ui` with missing widget placeholders so uic generates them
- regenerate `captured_ui_mainwindow.h.txt`
- update `mainwindow.h` declarations for APNG and new button slots

## Testing
- `./linux_build_script.sh` *(fails: Frame_Interpolation.o, Right-click_Menu.o, SystemTrayIcon.o)*

------
https://chatgpt.com/codex/tasks/task_e_684f7fad63f883229c05e846c6a5641b