### PR TITLE
Fix CI shader tool install and remove duplicate stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qtbase5-dev qt6-base-dev libegl1 cppcheck qt6-multimedia-dev qt6-declarative-dev qt6-5compat-dev qt6-shader-tools
+          sudo apt-get install -y qtbase5-dev qt6-base-dev libegl1 cppcheck qt6-multimedia-dev qt6-declarative-dev qt6-5compat-dev qt6-shader-baker
           pip install -r requirements.txt
       - name: Static analysis
         run: |

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -541,10 +541,6 @@ void MainWindow::Add_File_Folder_IncludeSubFolder_MainThread(QString Full_Path)
     Add_File_Folder_IncludeSubFolder(Full_Path);
 }
 
-void MainWindow::on_pushButton_CustRes_cancel_clicked()
-{
-    // TODO: Implement custom resolution cancel logic
-}
 
 MainWindow::~MainWindow()
 {
@@ -3506,43 +3502,6 @@ void MainWindow::on_pushButton_BlockSize_Add_W2xConverter_clicked(){}
 void MainWindow::on_pushButton_BlockSize_Minus_W2xConverter_clicked(){}
 void MainWindow::on_pushButton_Add_TileSize_SrmdNCNNVulkan_clicked(){}
 void MainWindow::on_pushButton_Minus_TileSize_SrmdNCNNVulkan_clicked(){}
-void MainWindow::on_pushButton_Add_TileSize_RealsrNCNNVulkan_clicked(){}
-void MainWindow::on_pushButton_Minus_TileSize_RealsrNCNNVulkan_clicked(){}
-void MainWindow::on_pushButton_DetectGPU_VFI_clicked(){}
-void MainWindow::on_lineEdit_MultiGPU_IDs_VFI_editingFinished(){}
-void MainWindow::on_checkBox_MultiGPU_VFI_stateChanged(int){}
-void MainWindow::on_groupBox_FrameInterpolation_clicked(){}
-void MainWindow::on_checkBox_isCompatible_RifeNcnnVulkan_clicked(){}
-void MainWindow::on_comboBox_Engine_VFI_currentIndexChanged(int){}
-void MainWindow::on_checkBox_isCompatible_CainNcnnVulkan_clicked(){}
-void MainWindow::on_pushButton_Verify_MultiGPU_VFI_clicked(){}
-void MainWindow::on_checkBox_EnableVFI_Home_clicked(){}
-void MainWindow::on_checkBox_MultiThread_VFI_stateChanged(int){}
-void MainWindow::on_checkBox_MultiThread_VFI_clicked(){}
-void MainWindow::on_checkBox_isCompatible_DainNcnnVulkan_clicked(){}
-void MainWindow::on_pushButton_SupportersList_clicked(){}
-void MainWindow::Table_EnableSorting(bool){}
-void MainWindow::Apply_CustRes_QAction_FileList_slot(){}
-void MainWindow::Cancel_CustRes_QAction_FileList_slot(){}
-void MainWindow::RemoveALL_image_slot(){}
-void MainWindow::RemoveALL_gif_slot(){}
-void MainWindow::RemoveALL_video_slot(){}
-void MainWindow::Add_progressBar_CompatibilityTest(){}
-void MainWindow::OpenSelectedFilesFolder_FilesList(){}
-void MainWindow::OpenSelectedFile_FilesList(){}
-void MainWindow::OpenOutputFolder(){}
-void MainWindow::Unable2Connect_RawGithubusercontentCom(){}
-void MainWindow::SystemTray_hide_self(){}
-void MainWindow::SystemTray_showNormal_self(){}
-void MainWindow::SystemTray_showDonate(){}
-void MainWindow::SystemTray_NewMessage(QString){}
-void MainWindow::EnableBackgroundMode_SystemTray(){}
-void MainWindow::on_activatedSysTrayIcon(QSystemTrayIcon::ActivationReason){}
-void MainWindow::progressbar_setRange_min_max(int,int){}
-void MainWindow::progressbar_Add(){}
-void MainWindow::Table_image_ChangeStatus_rowNumInt_statusQString(int,QString){}
-void MainWindow::Table_gif_ChangeStatus_rowNumInt_statusQString(int,QString){}
-void MainWindow::Table_video_ChangeStatus_rowNumInt_statusQString(int,QString){}
 void MainWindow::Waifu2x_Finished(){}
 void MainWindow::Waifu2x_Finished_manual(){}
 void MainWindow::TextBrowser_NewMessage(QString){}

--- a/linux_build_script.sh
+++ b/linux_build_script.sh
@@ -37,6 +37,9 @@ $QMAKE_EXECUTABLE Waifu2x-Extension-QT.pro -spec linux-g++ CONFIG+=debug
 echo "Cleaning specific build artifacts..."
 rm -f shaders/liquidglass.frag.qsb Beya_Waifu
 
+# Manually compile the liquidglass shader
+"$QTDIR/bin/qsb" Waifu2x-Extension-QT/shaders/liquidglass.frag -o Waifu2x-Extension-QT/shaders/liquidglass.frag.qsb
+
 # Build the project and redirect all output (stdout and stderr) to WinBuildErrorLog.md
 # Using script to tee output to file and stdout
 (make -j$(nproc) 2>&1) | tee ../WinBuildErrorLog.md


### PR DESCRIPTION
## Summary
- use `qt6-shader-baker` in CI workflow
- compile liquidglass shader manually in build script
- remove stubbed slot duplicates from `mainwindow.cpp`

## Testing
- `bash linux_build_script.sh` *(fails: Unknown Qt module multimedia core5compat)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684f8fb057448322879882b06c9a56d0