### PR TITLE
Fix missing brace around language handler

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -1057,6 +1057,7 @@ void MainWindow::on_comboBox_language_currentIndexChanged(int index)
         {
             ui->comboBox_language->setCurrentIndex(2);
         }
+    }
     QString qmFilename="";
     switch(ui->comboBox_language->currentIndex())
     {


### PR DESCRIPTION
## Summary
- resolve missing brace in `on_comboBox_language_currentIndexChanged`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc14e5f288322b997287d72069206