### PR TITLE
Fix Read_urls missing brace

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -3507,6 +3507,7 @@ void MainWindow::Read_urls(QList<QUrl> urls)
     // the behaviour used when adding files through the "Browse" button
     // so the UI remains consistent.
     ui_tableViews_setUpdatesEnabled(false);
+}
 void MainWindow::CurrentFileProgress_Stop(){}
 void MainWindow::CurrentFileProgress_progressbar_Add(){}
 void MainWindow::CurrentFileProgress_progressbar_Add_SegmentDuration(int){}


### PR DESCRIPTION
## Summary
- close `Read_urls` by adding the missing brace

## Testing
- `g++ -std=c++17 -fsyntax-only -I./Waifu2x-Extension-QT -I./Waifu2x-Extension-QT/include -I. $(pkg-config --cflags Qt6Widgets Qt6Core Qt6Gui Qt6Network Qt6Multimedia Qt6Concurrent Qt6Core5Compat) Waifu2x-Extension-QT/mainwindow.cpp` *(fails: `ui_mainwindow.h` missing)*
- `bash simple_build.sh` *(fails: No rule to make target 'shaders/liquidglass.frag.qsb')*

------
https://chatgpt.com/codex/tasks/task_e_684fc5c866808322939729f69277974c