### PR TITLE
Fix QtConcurrent run syntax and update-check typos

### DIFF
--- a/Waifu2x-Extension-QT/checkupdate.cpp
+++ b/Waifu2x-Extension-QT/checkupdate.cpp
@@ -34,7 +34,7 @@ void MainWindow::on_pushButton_CheckUpdate_clicked()
 Automatic update check:
 When the software starts, it runs in a separate thread to detect updates. If there is an update, a pop-up window will be displayed.
 */
-int MainWindow::CheckUpadte_Auto()
+int MainWindow::CheckUpdate_Auto()
 {
     bool isGiteeBanned = ui->checkBox_BanGitee->isChecked();
     //============
@@ -85,7 +85,7 @@ int MainWindow::CheckUpadte_Auto()
         Latest_Ver = Latest_Ver.trimmed();
         if(Latest_Ver!=Current_Ver&&Latest_Ver!="")
         {
-            emit Send_CheckUpadte_NewUpdate(Latest_Ver,Change_log);
+            emit Send_CheckUpdate_NewUpdate(Latest_Ver, Change_log);
         }
         else
         {
@@ -125,7 +125,7 @@ int MainWindow::CheckUpadte_Auto()
             Latest_Ver = Latest_Ver.trimmed();
             if(Latest_Ver!=Current_Ver&&Latest_Ver!="")
             {
-                emit Send_CheckUpadte_NewUpdate(Latest_Ver,Change_log);
+                emit Send_CheckUpdate_NewUpdate(Latest_Ver, Change_log);
             }
             else
             {
@@ -151,7 +151,7 @@ int MainWindow::CheckUpadte_Auto()
 /*
 Automatic update pop-up window
 */
-int MainWindow::CheckUpadte_NewUpdate(QString update_str,QString Change_log)
+int MainWindow::CheckUpdate_NewUpdate(QString update_str, QString Change_log)
 {
     QString UpdateType=ui->comboBox_UpdateChannel->currentText();
     //======

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -304,7 +304,7 @@ MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
     connect(this, SIGNAL(Send_Waifu2x_Compatibility_Test_finished()), this, SLOT(Waifu2x_Compatibility_Test_finished()));
     connect(this, SIGNAL(Send_Waifu2x_DetectGPU_finished()), this, SLOT(Waifu2x_DetectGPU_finished()));
     connect(this, SIGNAL(Send_Realsr_ncnn_vulkan_DetectGPU_finished()), this, SLOT(Realsr_ncnn_vulkan_DetectGPU_finished()));
-    connect(this, SIGNAL(Send_CheckUpadte_NewUpdate(QString,QString)), this, SLOT(CheckUpadte_NewUpdate(QString,QString)));
+    connect(this, SIGNAL(Send_CheckUpdate_NewUpdate(QString,QString)), this, SLOT(CheckUpdate_NewUpdate(QString,QString)));
     connect(this, SIGNAL(Send_SystemShutDown()), this, SLOT(SystemShutDown()));
     connect(this, SIGNAL(Send_Waifu2x_DumpProcessorList_converter_finished()), this, SLOT(Waifu2x_DumpProcessorList_converter_finished()));
     connect(this, SIGNAL(Send_Read_urls_finfished()), this, SLOT(Read_urls_finfished())); // Connect the signal to the correct original finishing slot
@@ -335,7 +335,7 @@ MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
     gpuManager.detectGPUs(""); // Pass empty string for initial/general detection
     QtConcurrent::run([this] { this->DeleteErrorLog_Waifu2xCaffe(); });
     QtConcurrent::run([this] { this->Del_TempBatFile(); });
-    AutoUpdate = QtConcurrent::run([this] { return this->CheckUpadte_Auto(); });
+    AutoUpdate = QtConcurrent::run([this] { return this->CheckUpdate_Auto(); });
     DownloadOnlineQRCode = QtConcurrent::run([this] { return this->Donate_DownloadOnlineQRCode(); }); // Assuming Donate_DownloadOnlineQRCode also returns int
     SystemShutDown_isAutoShutDown();
     TextBrowser_StartMes();
@@ -786,7 +786,7 @@ void MainWindow::on_pushButton_Stop_clicked()
     waifu2x_STOP = true;
     QProcess_stop = true;
     emit TextBrowser_NewMessage(tr("Trying to stop, please wait..."));
-    QtConcurrent::run(this, &MainWindow::Wait_waifu2x_stop);
+    QtConcurrent::run(&MainWindow::Wait_waifu2x_stop, this);
 }
 
 void MainWindow::Wait_waifu2x_stop()
@@ -803,7 +803,7 @@ void MainWindow::Wait_waifu2x_stop()
                 Delay_msec_sleep(300);
             }
             emit TextBrowser_NewMessage(tr("Processing of files has stopped."));
-            QtConcurrent::run(this, &MainWindow::Play_NFSound);
+            QtConcurrent::run(&MainWindow::Play_NFSound, this);
             break;
         }
         Delay_msec_sleep(300);
@@ -1602,7 +1602,7 @@ void MainWindow::on_pushButton_ForceRetry_clicked()
         return;
     }
     ui->pushButton_ForceRetry->setEnabled(0);
-    QtConcurrent::run(this, &MainWindow::isForceRetryClicked_SetTrue_Block_Anime4k);
+    QtConcurrent::run(&MainWindow::isForceRetryClicked_SetTrue_Block_Anime4k, this);
     ForceRetryCount++;
     QProcess Close;
     Close.start("taskkill /f /t /fi \"imagename eq Anime4K_waifu2xEX.exe\"");
@@ -2068,7 +2068,7 @@ void MainWindow::on_comboBox_UpdateChannel_currentIndexChanged(int index)
 {
     if(isClicked_comboBox_UpdateChannel && AutoUpdate.isRunning()==false)
     {
-        AutoUpdate = QtConcurrent::run(this, &MainWindow::CheckUpadte_Auto);
+        AutoUpdate = QtConcurrent::run(&MainWindow::CheckUpdate_Auto, this);
     }
 }
 void MainWindow::on_checkBox_ReplaceOriginalFile_stateChanged(int arg1)
@@ -2242,7 +2242,7 @@ void MainWindow::Set_checkBox_DisableResize_gif_Checked()
 void MainWindow::on_pushButton_TurnOffScreen_clicked()
 {
     if(TurnOffScreen_QF.isRunning() == true)return;
-    TurnOffScreen_QF = QtConcurrent::run(this, &MainWindow::TurnOffScreen);
+    TurnOffScreen_QF = QtConcurrent::run(&MainWindow::TurnOffScreen, this);
 }
 
 void MainWindow::TurnOffScreen()
@@ -3288,7 +3288,7 @@ void MainWindow::TextBrowser_StartMes(){}
 void MainWindow::Init_ActionsMenu_checkBox_ReplaceOriginalFile(){}
 void MainWindow::Init_ActionsMenu_checkBox_DelOriginal(){}
 int MainWindow::Settings_Read_Apply(){ return 0; }
-int MainWindow::CheckUpadte_Auto(){ return 0; }
+int MainWindow::CheckUpdate_Auto(){ return 0; }
 int MainWindow::Donate_DownloadOnlineQRCode(){ return 0; }
 int MainWindow::SystemShutDown_isAutoShutDown(){ return 0; }
 void MainWindow::file_mkDir(QString){}
@@ -3489,7 +3489,7 @@ int MainWindow::Waifu2x_DetectGPU()
 int MainWindow::Waifu2x_DetectGPU_finished(){ return 0; }
 int MainWindow::Realsr_ncnn_vulkan_DetectGPU_finished(){ return 0; }
 int MainWindow::FrameInterpolation_DetectGPU_finished(){ return 0; }
-int MainWindow::CheckUpadte_NewUpdate(QString,QString){ return 0; }
+int MainWindow::CheckUpdate_NewUpdate(QString,QString){ return 0; }
 void MainWindow::FinishedProcessing_DN(){}
 void MainWindow::Table_image_CustRes_rowNumInt_HeightQString_WidthQString(int,QString,QString){}
 void MainWindow::Table_gif_CustRes_rowNumInt_HeightQString_WidthQString(int,QString,QString){}

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -557,7 +557,7 @@ public:
     long unsigned int ETA=0;
     long unsigned int Progressbar_MaxVal = 0;
     long unsigned int Progressbar_CurrentVal = 0;
-    int CheckUpadte_Auto();
+    int CheckUpdate_Auto();
     int Donate_DownloadOnlineQRCode();
     void on_checkBox_BanGitee_clicked();
     bool isSettingsHide=false;
@@ -706,7 +706,7 @@ public slots: // Changed from 'slots:' for clarity, Qt treats them as public slo
     int Waifu2x_DetectGPU_finished();
     int Realsr_ncnn_vulkan_DetectGPU_finished(); // For RealSR (distinct from RealESRGAN)
     int FrameInterpolation_DetectGPU_finished();
-    int CheckUpadte_NewUpdate(QString update_str,QString Change_log);
+    int CheckUpdate_NewUpdate(QString update_str, QString Change_log);
     void FinishedProcessing_DN();
     int Table_FileCount_reload();
     void Table_image_insert_fileName_fullPath(QString fileName, QString SourceFile_fullPath);
@@ -905,7 +905,7 @@ signals:
     void Send_Realsr_ncnn_vulkan_DetectGPU_finished(); // For RealSR
     void Send_FrameInterpolation_DetectGPU_finished();
     void Send_Realesrgan_ncnn_vulkan_DetectGPU_finished(); // For RealESRGAN
-    void Send_CheckUpadte_NewUpdate(QString, QString);
+    void Send_CheckUpdate_NewUpdate(QString, QString);
     void Send_Table_FileCount_reload();
     void Send_Table_image_insert_fileName_fullPath(QString fileName, QString SourceFile_fullPath);
     void Send_Table_gif_insert_fileName_fullPath(QString fileName, QString SourceFile_fullPath);


### PR DESCRIPTION
## Summary
- correct QtConcurrent::run usage
- fix typos in update check functions
- rename signal/slot to `CheckUpdate`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `bash simple_build.sh` *(fails: No rule to make target 'shaders/liquidglass.frag.qsb')*

------
https://chatgpt.com/codex/tasks/task_e_684fc85f2edc832288f1ef4bc20e8857