### PR TITLE
Improve docs and shader build

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ Below is the start-up screen of the optional launcher:
 - Refer to the [Real-CUGAN](https://github.com/bilibili/ailab/tree/main/Real-CUGAN)
   and [Real-ESRGAN](https://github.com/xinntao/Real-ESRGAN) documentation for
   detailed usage and model descriptions.
+- If `pytest` reports missing modules such as `PySide6` or `Pillow`, run
+  `pip install -r requirements.txt` to install the Python dependencies.
+- When `simple_build.sh` fails with errors about `*.qsb` files, install the Qt 6
+  shader tools package: `sudo apt install qt6-shadertools-dev`.
 
 ## Tests
 

--- a/simple_build.sh
+++ b/simple_build.sh
@@ -72,22 +72,17 @@ if command -v qsb6 &> /dev/null; then
     QSB_CMD="qsb6"
 elif command -v qsb &> /dev/null; then
     QSB_CMD="qsb"
+elif [ -f /usr/lib/qt6/bin/qsb ]; then
+    QSB_CMD="/usr/lib/qt6/bin/qsb"
+elif [ -f /usr/bin/qsb6 ]; then
+    QSB_CMD="/usr/bin/qsb6"
+elif [ -f /usr/lib/qt6/bin/qsb6 ]; then
+    QSB_CMD="/usr/lib/qt6/bin/qsb6"
 else
-    echo "qsb (or qsb6) not found in PATH."
-    # Try to find it in a standard location from apt install
-    if [ -f /usr/lib/qt6/bin/qsb ]; then # Common path for qsb after qt6-base-dev-tools
-        QSB_CMD="/usr/lib/qt6/bin/qsb"
-        echo "Found qsb at /usr/lib/qt6/bin/qsb"
-    elif [ -f /usr/bin/qsb6 ]; then
-        QSB_CMD="/usr/bin/qsb6"
-        echo "Found qsb6 at /usr/bin/qsb6"
-    elif [ -f /usr/lib/qt6/bin/qsb6 ]; then # Common path for qsb6
-        QSB_CMD="/usr/lib/qt6/bin/qsb6"
-        echo "Found qsb6 at /usr/lib/qt6/bin/qsb6"
-    else
-        echo "Could not find qsb or qsb6. Shader compilation might fail."
-        # Allow to continue, make might fail with a clearer error if qsb files are truly needed and not generated.
-    fi
+    echo "Could not find qsb or qsb6."
+    echo "Install the Qt 6 shader tools package, e.g.:"
+    echo "sudo apt install qt6-shadertools-dev"
+    exit 3
 fi
 
 if [ -n "$QSB_CMD" ]; then
@@ -98,8 +93,6 @@ if [ -n "$QSB_CMD" ]; then
         echo "Compiling $SHADER_FILE to $OUTPUT_NAME"
         $QSB_CMD "$SHADER_FILE" -o "$OUTPUT_NAME"
     done
-else
-    echo "Skipping shader compilation as qsb/qsb6 was not found."
 fi
 echo "Shader compilation finished."
 


### PR DESCRIPTION
## Summary
- add more troubleshooting notes to README
- fail early in simple_build.sh when `qsb` is missing

## Testing
- `pytest -q`
- `bash simple_build.sh > /tmp/build.log` *(fails: mainwindow.cpp errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fccb06f088322863a5e52323898a7