### PR TITLE
Fix Qt install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          qt-version: '6.5.2'
+          version: '6.5.2'
           modules: 'qtmultimedia qtshadertools qt5compat'
       - name: Install build tools
         run: |


### PR DESCRIPTION
## Summary
- specify `version` input in Windows CI

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_684fce6009548322a41d513f72658438