### PR TITLE
Fix cppcheck badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ During CI the Windows workflow captures the pytest output into
 The log can be downloaded from the workflow run's "Artifacts" section.
 
 ## Static Analysis
-[![cppcheck](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml/badge.svg)](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/cppcheck.yml)
+[![cppcheck](https://github.com/beyawnko/Beya_Waifu/actions/workflows/cppcheck.yml/badge.svg)](https://github.com/beyawnko/Beya_Waifu/actions/workflows/cppcheck.yml)
 
 Static analysis can be performed with [cppcheck](https://cppcheck.sourceforge.io/). The helper script expects `cppcheck`, `pkg-config` and the Qt development headers to be present. If `pkg-config` cannot locate Qt, install the development package providing the Qt pkg-config files (e.g., `qtbase5-dev` or `qtbase6-dev`). On Debian-based distributions install them with:
 


### PR DESCRIPTION
## Summary
- update cppcheck badge URL in `README.md`

## Testing
- `bash -x tools/run_cppcheck.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684fd070ac2c8322b639c036d3137265