### PR TITLE
Remove pragma once

### DIFF
--- a/Waifu2x-Extension-QT/realesrgan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realesrgan_ncnn_vulkan.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "mainwindow.h"
 #include <QDebug>
 


### PR DESCRIPTION
## Summary
- remove stray header-guard pragma from a C++ source file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd2ed40048322b2c1591589f987a9