### PR TITLE
Fix GPU job config temp types

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -94,7 +94,7 @@ void RealCuganProcessor::readSettingsVideoGif(int ThreadNum)
                 m_mainWindow->checkBox_MultiGPU_RealCUGAN->isChecked(),
                 m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN,
                 fallbackId);
-    m_mainWindow->m_realcugan_gpuJobConfig_temp = gpuJobConfig;
+    m_mainWindow->m_realcugan_gpuJobConfig_temp = m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN;
     qDebug() << "Realcugan_NCNN_Vulkan_ReadSettings_Video_GIF for ThreadNum" << ThreadNum
              << "GPU/Job Config:" << gpuJobConfig;
 }

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -308,7 +308,7 @@ public:
     int m_realcugan_TileSize;
     bool m_realcugan_TTA;
     QString m_realcugan_GPUID;
-    QString m_realcugan_gpuJobConfig_temp;
+    QList<QMap<QString, QString>> m_realcugan_gpuJobConfig_temp;
     QList<QProcess*> ProcList_RealCUGAN;
     QStringList Available_GPUID_RealCUGAN;
     QList<QMap<QString, QString>> GPUIDs_List_MultiGPU_RealCUGAN;
@@ -335,7 +335,7 @@ public:
     int m_realesrgan_TileSize;
     bool m_realesrgan_TTA;
     QString m_realesrgan_GPUID;
-    QString m_realesrgan_gpuJobConfig_temp;
+    QList<QMap<QString, QString>> m_realesrgan_gpuJobConfig_temp;
     QList<QProcess*> ProcList_RealESRGAN;
     QStringList Available_GPUID_RealESRGAN_ncnn_vulkan;
     QList<QMap<QString, QString>> GPUIDs_List_MultiGPU_RealesrganNcnnVulkan;


### PR DESCRIPTION
## Summary
- use structured list type for temporary RealCUGAN and RealESRGAN GPU job settings
- sync RealCuganProcessor to store the multi-GPU config list

## Testing
- `pip install Pillow PySide6 pytest-subtests -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505e1a55148322806991455ff57263