### PR TITLE
Add AGPL header to Logger

### DIFF
--- a/Waifu2x-Extension-QT/Logger.cpp
+++ b/Waifu2x-Extension-QT/Logger.cpp
@@ -1,3 +1,22 @@
+/*
+    Copyright (C) 2025  beyawnko
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    My Github homepage: https://github.com/beyawnko
+*/
+
 #include "Logger.h"
 #include <QFile>
 #include <QDateTime>

--- a/Waifu2x-Extension-QT/Logger.h
+++ b/Waifu2x-Extension-QT/Logger.h
@@ -1,4 +1,23 @@
 #pragma once
+/*
+    Copyright (C) 2025  beyawnko
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    My Github homepage: https://github.com/beyawnko
+*/
+
 #include <QString>
 
 /**


### PR DESCRIPTION
## Summary
- add AGPL license comment to `Logger.cpp` and `Logger.h`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PySide6 and Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_685123d6f57883229b59089390e05681