### PR TITLE
Add O3/native flags to release builds

### DIFF
--- a/realcugan-ncnn-vulkan/src/CMakeLists.txt
+++ b/realcugan-ncnn-vulkan/src/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.9)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE release CACHE STRING "Choose the type of build" FORCE)
 endif()
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native" CACHE STRING "Release flags" FORCE)
 
 option(USE_SYSTEM_NCNN "build with system libncnn" OFF)
 option(USE_SYSTEM_WEBP "build with system libwebp" OFF)

--- a/realesrgan-ncnn-vulkan/src/CMakeLists.txt
+++ b/realesrgan-ncnn-vulkan/src/CMakeLists.txt
@@ -19,6 +19,7 @@ project(realesrgan-ncnn-vulkan)
 cmake_minimum_required(VERSION 3.9)
 
 set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native" CACHE STRING "Release flags" FORCE)
 
 option(USE_SYSTEM_NCNN "build with system libncnn" OFF)
 option(USE_SYSTEM_WEBP "build with system libwebp" OFF)


### PR DESCRIPTION
## Summary
- add `-O3 -march=native` to RealCUGAN and RealESRGAN CMake release flags

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ce4feedc8322b3747f97f1c46dd9