### PR TITLE
Add RealCUGAN multi GPU helpers

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -35,31 +35,32 @@ void RealCuganProcessor::preLoadSettings()
     QSettings settings("Waifu2x-Extension-QT", "Waifu2x-Extension-QT");
     settings.beginGroup("RealCUGAN_NCNN_Vulkan");
     // Fallback to stored values when specific UI widgets are not available.
-    QVariant modelVar = settings.value("Model", "models-se");
+    QVariant modelVar = settings.value("RealCUGAN_Model", "models-se");
     if (m_mainWindow->comboBox_Model_RealCUGAN)
         m_mainWindow->comboBox_Model_RealCUGAN->setCurrentText(modelVar.toString());
 
-    QVariant denoiseVar = settings.value("DenoiseLevel", -1);
+    QVariant denoiseVar = settings.value("RealCUGAN_DenoiseLevel", -1);
     if (m_mainWindow->spinBox_DenoiseLevel_RealCUGAN)
         m_mainWindow->spinBox_DenoiseLevel_RealCUGAN->setValue(denoiseVar.toInt());
 
-    QVariant tileVar = settings.value("TileSize", 0);
+    QVariant tileVar = settings.value("RealCUGAN_TileSize", 0);
     if (m_mainWindow->spinBox_TileSize_RealCUGAN)
         m_mainWindow->spinBox_TileSize_RealCUGAN->setValue(tileVar.toInt());
 
-    QVariant ttaVar = settings.value("TTA", false);
+    QVariant ttaVar = settings.value("RealCUGAN_TTA", false);
     if (m_mainWindow->checkBox_TTA_RealCUGAN)
         m_mainWindow->checkBox_TTA_RealCUGAN->setChecked(ttaVar.toBool());
 
-    QVariant gpuVar = settings.value("GPUID", "0: Default GPU 0");
+    QVariant gpuVar = settings.value("RealCUGAN_GPUID", "0: Default GPU 0");
     if (m_mainWindow->comboBox_GPUID_RealCUGAN)
         m_mainWindow->comboBox_GPUID_RealCUGAN->setCurrentText(gpuVar.toString());
 
-    QVariant multiVar = settings.value("MultiGPUEnabled", false);
+    QVariant multiVar = settings.value("RealCUGAN_MultiGPU_Enabled", false);
     if (m_mainWindow->checkBox_MultiGPU_RealCUGAN)
         m_mainWindow->checkBox_MultiGPU_RealCUGAN->setChecked(multiVar.toBool());
 
-    m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN = settings.value("MultiGPU_List").value<QList_QMap_QStrQStr>();
+    m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN =
+        settings.value("RealCUGAN_GPUJobConfig_MultiGPU").value<QList_QMap_QStrQStr>();
     if (m_mainWindow->listWidget_GPUList_MultiGPU_RealCUGAN) {
         m_mainWindow->listWidget_GPUList_MultiGPU_RealCUGAN->clear();
         for(const auto &gpuMap : m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN) {
@@ -87,24 +88,24 @@ void RealCuganProcessor::readSettings()
 
     m_mainWindow->m_realcugan_Model = m_mainWindow->comboBox_Model_RealCUGAN
             ? m_mainWindow->comboBox_Model_RealCUGAN->currentText()
-            : settings.value("Model", "models-se").toString();
+            : settings.value("RealCUGAN_Model", "models-se").toString();
     m_mainWindow->m_realcugan_DenoiseLevel = m_mainWindow->spinBox_DenoiseLevel_RealCUGAN
             ? m_mainWindow->spinBox_DenoiseLevel_RealCUGAN->value()
-            : settings.value("DenoiseLevel", -1).toInt();
+            : settings.value("RealCUGAN_DenoiseLevel", -1).toInt();
     m_mainWindow->m_realcugan_TileSize = m_mainWindow->spinBox_TileSize_RealCUGAN
             ? m_mainWindow->spinBox_TileSize_RealCUGAN->value()
-            : settings.value("TileSize", 0).toInt();
+            : settings.value("RealCUGAN_TileSize", 0).toInt();
     m_mainWindow->m_realcugan_TTA = m_mainWindow->checkBox_TTA_RealCUGAN
             ? m_mainWindow->checkBox_TTA_RealCUGAN->isChecked()
-            : settings.value("TTA", false).toBool();
+            : settings.value("RealCUGAN_TTA", false).toBool();
 
     bool multiEnabled = m_mainWindow->checkBox_MultiGPU_RealCUGAN
             ? m_mainWindow->checkBox_MultiGPU_RealCUGAN->isChecked()
-            : settings.value("MultiGPUEnabled", false).toBool();
+            : settings.value("RealCUGAN_MultiGPU_Enabled", false).toBool();
 
     QString comboGpu = m_mainWindow->comboBox_GPUID_RealCUGAN
             ? m_mainWindow->comboBox_GPUID_RealCUGAN->currentText()
-            : settings.value("GPUID", "0: Default GPU 0").toString();
+            : settings.value("RealCUGAN_GPUID", "0: Default GPU 0").toString();
 
     if (multiEnabled) {
         if (!m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN.isEmpty()) {
@@ -132,13 +133,7 @@ void RealCuganProcessor::readSettingsVideoGif(int ThreadNum)
     readSettings();
     QSettings settings("Waifu2x-Extension-QT", "Waifu2x-Extension-QT");
     settings.beginGroup("RealCUGAN_NCNN_Vulkan"); // Needed when widgets are missing
-    QString fallbackId = m_mainWindow->m_realcugan_GPUID.split(":").first();
-    QString gpuJobConfig = m_jobManager.buildGpuJobString(
-                m_mainWindow->checkBox_MultiGPU_RealCUGAN
-                    ? m_mainWindow->checkBox_MultiGPU_RealCUGAN->isChecked()
-                    : settings.value("MultiGPUEnabled", false).toBool(),
-                m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN,
-                fallbackId);
+    QString gpuJobConfig = m_mainWindow->RealcuganNcnnVulkan_MultiGPU();
     m_mainWindow->m_realcugan_gpuJobConfig_temp = m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN;
     qDebug() << "Realcugan_NCNN_Vulkan_ReadSettings_Video_GIF for ThreadNum" << ThreadNum
              << "GPU/Job Config:" << gpuJobConfig;

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -493,6 +493,46 @@ void MainWindow::on_pushButton_ClearGPU_MultiGPU_RealCUGAN_clicked()
         listWidget_GPUList_MultiGPU_RealCUGAN->clear();
 }
 
+/**
+ * @brief Build the job string for multi GPU execution.
+ *
+ * Uses RealcuganJobManager to convert the stored list to the
+ * formatted -g/-j options required by the executable.
+ */
+QString MainWindow::RealcuganNcnnVulkan_MultiGPU()
+{
+    RealcuganJobManager mgr;
+    QString fallback = m_realcugan_GPUID.split(":").first();
+    bool enabled = checkBox_MultiGPU_RealCUGAN && checkBox_MultiGPU_RealCUGAN->isChecked();
+    return mgr.buildGpuJobString(enabled,
+                                 GPUIDs_List_MultiGPU_RealCUGAN,
+                                 fallback);
+}
+
+/** Add a GPU ID with thread count to the internal list. */
+void MainWindow::AddGPU_MultiGPU_RealcuganNcnnVulkan(const QString &gpuid, int threads)
+{
+    for (const auto &gpu : GPUIDs_List_MultiGPU_RealCUGAN) {
+        if (gpu.value("ID") == gpuid)
+            return;
+    }
+    QMap<QString, QString> map;
+    map["ID"] = gpuid;
+    map["Threads"] = QString::number(threads);
+    GPUIDs_List_MultiGPU_RealCUGAN.append(map);
+}
+
+/** Remove a GPU ID from the internal list. */
+void MainWindow::RemoveGPU_MultiGPU_RealcuganNcnnVulkan(const QString &gpuid)
+{
+    for (int i = 0; i < GPUIDs_List_MultiGPU_RealCUGAN.size(); ++i) {
+        if (GPUIDs_List_MultiGPU_RealCUGAN.at(i).value("ID") == gpuid) {
+            GPUIDs_List_MultiGPU_RealCUGAN.removeAt(i);
+            break;
+        }
+    }
+}
+
 /** Increase the RealCUGAN tile size by the spin box step. */
 void MainWindow::on_pushButton_TileSize_Add_RealCUGAN_clicked()
 {

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -342,8 +342,14 @@ public:
     void Realcugan_NCNN_Vulkan_ReadSettings_Video_GIF(int ThreadNum);
     bool APNG_RealcuganNCNNVulkan(QString splitFramesFolder, QString scaledFramesFolder, QString sourceFileFullPath, QStringList framesFileName_qStrList, QString resultFileFullPath);
     void Realcugan_ncnn_vulkan_DetectGPU();
+    /** Build the -g job string based on the stored GPU list. */
     QString RealcuganNcnnVulkan_MultiGPU();
-    void AddGPU_MultiGPU_RealcuganNcnnVulkan(QString GPUID);
+
+    /** Add a GPU with thread count to the multi GPU list. */
+    void AddGPU_MultiGPU_RealcuganNcnnVulkan(const QString &gpuid, int threads = 1);
+
+    /** Remove a GPU from the multi GPU list. */
+    void RemoveGPU_MultiGPU_RealcuganNcnnVulkan(const QString &gpuid);
     void Realcugan_NCNN_Vulkan_PreLoad_Settings();
     QString Realcugan_NCNN_Vulkan_PreLoad_Settings_Str = "";
     QStringList Realcugan_NCNN_Vulkan_PrepareArguments(const QString &inputFile, const QString &outputFile, int currentPassScale, const QString &modelName, int denoiseLevel, int tileSize, const QString &gpuId, bool ttaEnabled, const QString &outputFormat, bool isMultiGPU, const QString &multiGpuJobArgs, bool experimental);


### PR DESCRIPTION
## Summary
- implement job string builder and list management helpers in `mainwindow`
- integrate multi GPU helpers into `RealCuganProcessor`
- adjust settings keys to match saving/loading logic

## Testing
- `pip install PySide6 Pillow`
- `pytest -q` *(fails: fixture 'subtests' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685209a88d94832283d7decf4fe0b695