### PR TITLE
Return success boolean from FileManager::moveToTrash

### DIFF
--- a/Waifu2x-Extension-QT/FileManager.h
+++ b/Waifu2x-Extension-QT/FileManager.h
@@ -23,7 +23,12 @@ public:
     QStringList getFileNamesNoFilter(const QString &path);
     bool deleteDir(const QString &path);
     QString getBaseName(const QString &path);
-    void moveToTrash(const QString &file);
+    /**
+     * @brief Move the specified file to the system trash.
+     * @param file Absolute file path to remove.
+     * @return True if the file was successfully moved.
+     */
+    bool moveToTrash(const QString &file);
     QString getFolderPath(const QFileInfo &fileInfo);
     bool isDirWritable(const QString &dirPath);
     bool openFolder(const QString &folderPath);


### PR DESCRIPTION
## Summary
- return a boolean from `FileManager::moveToTrash`
- document `moveToTrash` in the header
- adjust `ReplaceOriginalFile` to handle failure

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852488a54808322aab372fcd662e188