### PR TITLE
Fix QMediaPlayer error connection

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -41,6 +41,7 @@ Copyright (C) 2025  beyawnko
 #include <QImageReader>
 #include <QMovie>
 #include <QMediaPlayer>
+#include <QMediaMetaData>
 #include <QEventLoop> // Required for waiting on QMediaPlayer signals
 #include <QDesktopServices> // For opening URLs
 #include <QStandardItem> // For table view item manipulation
@@ -2286,7 +2287,7 @@ FileMetadataCache MainWindow::getOrFetchMetadata(const QString &filePath)
             }
         });
 
-        connect(&player, QOverload<QMediaPlayer::Error, const QString &>::of(&QMediaPlayer::error),
+        connect(&player, &QMediaPlayer::errorOccurred,
             [&](QMediaPlayer::Error error, const QString &errorString) {
             qWarning() << "getOrFetchMetadata: QMediaPlayer error for" << filePath << "Error:" << error << errorString;
             metadataSuccessfullyLoaded = true; // Ensure loop quits on error


### PR DESCRIPTION
## Summary
- connect to `QMediaPlayer::errorOccurred` signal
- add include for `QMediaMetaData`
- install PySide6/Pillow to run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852488eec588322bb4020a8414b84c5