### PR TITLE
Add settings default support

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -2366,10 +2366,13 @@ bool MainWindow::Realcugan_ProcessSingleFileIteratively(const QString &inputFile
     // These could be specific to the type of content if known (image, video frame, gif frame)
     // For generic iterative processing, using generic keys or fallback to current m_realcugan_ members.
     // Using general settings keys for now.
-    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsGeneric", "1:1:1").toString();
-    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapGeneric", "3").toString();
+    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsGeneric",
+                                         QString("1:1:1")).toString();
+    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapGeneric",
+                                          QString("3")).toString();
     // verboseLog could also be a member like m_realcugan_verboseLog if it's a global setting for RealCUGAN
-    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog", false).toBool();
+    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog",
+                                         QVariant(false)).toBool();
 
 
     if (!realCuganProcessor)

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -528,6 +528,12 @@ public:
     int Settings_Read_Apply();
     bool Settings_isReseted = false;
     QVariant Settings_Read_value(QString Key);
+    /**
+     * @brief Read a value from the settings file.
+     * @param key The key to look up.
+     * @param defaultValue The value to return if the key does not exist.
+     */
+    QVariant Settings_Read_value(const QString &key, const QVariant &defaultValue);
     bool isReadOldSettings = false;
     void PreLoad_Engines_Settings();
     int Calculate_Temporary_ScaleRatio_W2xNCNNVulkan(int ScaleRatio);

--- a/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
@@ -44,9 +44,12 @@ void MainWindow::Realcugan_NCNN_Vulkan_Image(int file_list_row_number, bool isBa
 
     QString outputFormat = ui->comboBox_ImageSaveFormat ? ui->comboBox_ImageSaveFormat->currentText().toLower() : "png";
 
-    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsImage", "1:1:1").toString();
-    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapImage", "3").toString();
-    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog", false).toBool();
+    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsImage",
+                                         QString("1:1:1")).toString();
+    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapImage",
+                                          QString("3")).toString();
+    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog",
+                                         QVariant(false)).toBool();
 
     bool isMultiGpu = ui->checkBox_MultiGPU_RealCUGAN ? ui->checkBox_MultiGPU_RealCUGAN->isChecked() : false;
     QString multiGpuJobArgsString;
@@ -158,9 +161,12 @@ void MainWindow::Realcugan_NCNN_Vulkan_Video_BySegment(int rowNum)
 
     realCuganProcessor->readSettingsVideoGif(0);
 
-    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsVideo", "1:2:2").toString();
-    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapVideo", "3").toString();
-    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog", false).toBool();
+    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsVideo",
+                                         QString("1:2:2")).toString();
+    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapVideo",
+                                          QString("3")).toString();
+    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog",
+                                         QVariant(false)).toBool();
 
     bool isMultiGpu = ui->checkBox_MultiGPU_RealCUGAN ? ui->checkBox_MultiGPU_RealCUGAN->isChecked() : false;
     QString multiGpuJobArgsString;
@@ -268,9 +274,12 @@ void MainWindow::Realcugan_NCNN_Vulkan_Video(int file_list_row_number)
 
     QString outputFormat = "png";
 
-    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsVideo", "1:2:2").toString();
-    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapVideo", "3").toString();
-    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog", false).toBool();
+    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsVideo",
+                                         QString("1:2:2")).toString();
+    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapVideo",
+                                          QString("3")).toString();
+    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog",
+                                         QVariant(false)).toBool();
 
     bool isMultiGpu = ui->checkBox_MultiGPU_RealCUGAN ? ui->checkBox_MultiGPU_RealCUGAN->isChecked() : false;
     QString multiGpuJobArgsString;
@@ -351,9 +360,12 @@ void MainWindow::Realcugan_NCNN_Vulkan_GIF(int file_list_row_number)
 
     QString outputFormat = "png";
 
-    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsGif", "1:2:2").toString();
-    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapGif", "3").toString();
-    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog", false).toBool();
+    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsGif",
+                                         QString("1:2:2")).toString();
+    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapGif",
+                                          QString("3")).toString();
+    bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog",
+                                         QVariant(false)).toBool();
 
     bool isMultiGpu = ui->checkBox_MultiGPU_RealCUGAN ? ui->checkBox_MultiGPU_RealCUGAN->isChecked() : false;
     QString multiGpuJobArgsString;
@@ -419,7 +431,8 @@ void MainWindow::Realcugan_NCNN_Vulkan_ReadSettings()
     if (m_mainWindow->spinBox_Scale_RealCUGAN) // Check if m_mainWindow is valid, and then spinBox
          m_realcugan_Scale = m_mainWindow->spinBox_Scale_RealCUGAN->value();
     else
-         m_realcugan_Scale = Settings_Read_value("RealCUGAN_Scale", 2).toInt();
+         m_realcugan_Scale =
+             Settings_Read_value("RealCUGAN_Scale", QVariant(2)).toInt();
 
 
     qDebug() << "[MW::R_ReadSettings] Model:" << m_realcugan_Model

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -1277,27 +1277,32 @@ int MainWindow::Settings_Read_Apply()
 
 QVariant MainWindow::Settings_Read_value(QString Key)
 {
-    QString settings_ini_old = Current_Path+"/settings_old.ini";
-    QString settings_ini_new = Current_Path+"/settings.ini";
-    QSettings *configIniRead_new = new QSettings(settings_ini_new, QSettings::IniFormat);
+    return Settings_Read_value(Key, QVariant());
+}
+
+QVariant MainWindow::Settings_Read_value(const QString &Key,
+                                         const QVariant &defaultValue)
+{
+    QString settings_ini_old = Current_Path + "/settings_old.ini";
+    QString settings_ini_new = Current_Path + "/settings.ini";
+    QSettings configIniRead_new(settings_ini_new, QSettings::IniFormat);
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-    configIniRead_new->setIniCodec(QTextCodec::codecForName("UTF-8"));
+    configIniRead_new.setIniCodec(QTextCodec::codecForName("UTF-8"));
 #endif
     //====
-    if(isReadOldSettings&&QFile::exists(settings_ini_old))
+    if (isReadOldSettings && QFile::exists(settings_ini_old))
     {
-        QSettings *configIniRead_old = new QSettings(settings_ini_old, QSettings::IniFormat);
+        QSettings configIniRead_old(settings_ini_old, QSettings::IniFormat);
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-        configIniRead_old->setIniCodec(QTextCodec::codecForName("UTF-8"));
+        configIniRead_old.setIniCodec(QTextCodec::codecForName("UTF-8"));
 #endif
         //====
-        if(configIniRead_old->contains(Key))
+        if (configIniRead_old.contains(Key))
         {
-            return configIniRead_old->value(Key);
+            return configIniRead_old.value(Key, defaultValue);
         }
-        return configIniRead_new->value(Key);
     }
-    return configIniRead_new->value(Key);
+    return configIniRead_new.value(Key, defaultValue);
 }
 
 /*


### PR DESCRIPTION
## Summary
- add overload of `Settings_Read_value` with default value parameter
- document function in `mainwindow.h`
- update RealCUGAN modules and mainwindow to use new overload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL and PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_6852488d23c88322bcec0bd58dc4bf20