### PR TITLE
Fix unused verboseLog variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The application queries available Vulkan devices by invoking the bundled upscale
 output lists devices as `GPU device <id>: <name>` or `[<id>] <name>` which is parsed to populate the GPU selection
 menus. Detected IDs are saved to `settings.ini` so that subsequent launches restore the last known device list.
 
+Verbose output from RealCUGAN can be enabled by setting `RealCUGANVerboseLog=true`
+in `settings.ini`. When enabled the `-v` flag is passed to the engine.
+
 ### Quick Build (Linux & Windows)
 
 1. Install **Qt 6.5** with the Widgets, Multimedia, OpenGL and Qt5Compat modules. A C++17 compiler is required (GCC 7+

--- a/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
+++ b/Waifu2x-Extension-QT/realcugan_ncnn_vulkan.cpp
@@ -162,13 +162,6 @@ void MainWindow::Realcugan_NCNN_Vulkan_Video_BySegment(int rowNum)
 
     realCuganProcessor->readSettingsVideoGif(0);
 
-    QString jobsStr = Settings_Read_value("/settings/RealCUGANJobsVideo",
-                                         QString("1:2:2")).toString();
-    QString syncGapStr = Settings_Read_value("/settings/RealCUGANSyncGapVideo",
-                                          QString("3")).toString();
-    // bool verboseLog = Settings_Read_value("/settings/RealCUGANVerboseLog",
-    //                                      QVariant(false)).toBool();
-    bool verboseLog = false; // Defaulting to false, or read from settings if still needed by prepareArguments
 
     bool isMultiGpu = ui->checkBox_MultiGPU_RealCUGAN ? ui->checkBox_MultiGPU_RealCUGAN->isChecked() : false;
     QString multiGpuJobArgsString;
@@ -206,8 +199,8 @@ void MainWindow::Realcugan_NCNN_Vulkan_Video_BySegment(int rowNum)
             // Realcugan_ProcessSingleFileIteratively is in mainwindow.cpp
             // It will use realCuganProcessor->prepareArguments itself.
             // We must ensure the parameters passed here are consistent with its needs.
-            // The jobsStr, syncGapStr, verboseLog are now part of prepareArguments,
-            // so Realcugan_ProcessSingleFileIteratively needs to be updated to pass them.
+            // jobsStr, syncGapStr and verboseLog are handled within
+            // Realcugan_ProcessSingleFileIteratively via settings.
             if (!Realcugan_ProcessSingleFileIteratively(inFile, outFile, videoScale, 0,0,
                                                        m_realcugan_Model, m_realcugan_DenoiseLevel, m_realcugan_TileSize,
                                                        m_realcugan_GPUID, // This is the single GPU ID


### PR DESCRIPTION
## Summary
- remove dead verboseLog and related variables from Realcugan_NCNN_Vulkan_Video_BySegment
- document how to enable verbose logging

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685270635dd08322b4e7d6cfdaa6f7e7