### PR TITLE
Remove drop file label references

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -62,90 +62,12 @@ MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
 {
     ui->setupUi(this);
 
-    // Re-layout for "Files List" title and table on the first tab
-    if (ui->tabWidget_Input && ui->tabWidget_Input->count() > 0) {
-        QWidget* imageTabPage = ui->tabWidget_Input->widget(0); // Get the first tab (presumably ui->tab_image)
-
-        if (imageTabPage && ui->tableView_image) {
-            qDebug() << "Attempting to re-layout image tab content.";
-
-            // 1. Create the new title label
-            QLabel* filesListTitleLabel = new QLabel(tr("Files List"), imageTabPage); // Parent to tab page initially
-
-            // 2. Create a container widget for the title and table
-            QWidget* containerWidget = new QWidget(imageTabPage); // Parent to tab page
-
-            // 3. Create the new QVBoxLayout for the container widget
-            QVBoxLayout* newVLayout = new QVBoxLayout(containerWidget); // Layout for the container
-
-            // 4. Reparent and add widgets to the new layout
-            // It's important to set the parent of widgets before adding them to a layout
-            // that belongs to a different parent, or ensure the layout's parent is correct.
-            // Here, containerWidget is the parent for newVLayout.
-            // filesListTitleLabel and ui->tableView_image should be children of containerWidget
-            // for newVLayout to manage them correctly *within* containerWidget.
-
-            filesListTitleLabel->setParent(containerWidget); // Reparent label to container
-            newVLayout->addWidget(filesListTitleLabel);
-
-            // If ui->tableView_image was previously in a layout on imageTabPage,
-            // it needs to be removed from that layout before being added to newVLayout.
-            // However, just reparenting it should be sufficient if it wasn't in a complex layout.
-            // QLayout* oldParentLayout = ui->tableView_image->parentWidget()->layout();
-            // if (oldParentLayout) {
-            //     oldParentLayout->removeWidget(ui->tableView_image);
-            // }
-            ui->tableView_image->setParent(containerWidget); // Reparent table to container
-            newVLayout->addWidget(ui->tableView_image);
-
-            newVLayout->setContentsMargins(5, 5, 5, 5); // Optional: adjust margins
-            newVLayout->setSpacing(5);                 // Optional: adjust spacing
-            containerWidget->setLayout(newVLayout);
-
-            // 5. Integrate containerWidget into imageTabPage's layout
-            QLayout* tabPageLayout = imageTabPage->layout();
-            if (tabPageLayout) {
-                // If tab page already has a layout, add our container to it.
-                // This assumes other widgets on the tab page are already in this layout.
-                // We'll add our new container at the top.
-                if (QVBoxLayout* vTabPageLayout = qobject_cast<QVBoxLayout*>(tabPageLayout)) {
-                    vTabPageLayout->insertWidget(0, containerWidget);
-                    qDebug() << "Inserted containerWidget into existing QVBoxLayout of imageTabPage.";
-                } else if (QGridLayout* gTabPageLayout = qobject_cast<QGridLayout*>(tabPageLayout)) {
-                    // If it's a grid, add container to row 0, col 0, spanning all columns if needed.
-                    // This might require knowing column span. For simplicity, add to 0,0.
-                    // Any other widgets in the grid layout need to be shifted or handled.
-                    // This is a potential point of visual disruption if not handled carefully.
-                    // For now, just add it; manual adjustment of the UI might be needed if it's a grid.
-                    gTabPageLayout->addWidget(containerWidget, 0, 0); // Add to row 0, column 0
-                    qDebug() << "Added containerWidget to existing QGridLayout of imageTabPage at (0,0).";
-                } else {
-                    // Other layout type - just add widget. May not be ideal.
-                    tabPageLayout->addWidget(containerWidget);
-                    qDebug() << "Added containerWidget to existing layout of imageTabPage (unknown type).";
-                }
-            } else {
-                // If tab page has no layout, create a new one and add our container.
-                // This will become the main layout for the tab page.
-                // WARNING: If there were other widgets directly on imageTabPage (not in a layout),
-                // they will no longer be managed by any layout unless explicitly added here.
-                QVBoxLayout* newTabPageLayout = new QVBoxLayout(imageTabPage);
-                newTabPageLayout->addWidget(containerWidget);
-                imageTabPage->setLayout(newTabPageLayout);
-                qDebug() << "Set new QVBoxLayout on imageTabPage and added containerWidget.";
-            }
-            qDebug() << "Re-layout of Files List title and table view attempted.";
-        } else {
-            if (!imageTabPage) {
-                qDebug() << "Could not find imageTabPage (first tab).";
-            }
-            if (!ui->tableView_image) {
-                qDebug() << "Could not find ui->tableView_image.";
-            }
-        }
-    } else {
-        qDebug() << "Could not find ui->tabWidget_Input or it has no tabs.";
-    }
+    /*
+     * Disabled block that previously re-parented the first image tab's table and
+     * inserted a new layout with a title label. The application no longer
+     * performs this dynamic re-layout and instead relies on the original UI
+     * design from the Qt form.
+     */
 
     // Initialize RealCUGAN pointers to ensure safe use when the
     // dedicated widgets are absent. Fallback to Frame Interpolation

--- a/Waifu2x-Extension-QT/table.cpp
+++ b/Waifu2x-Extension-QT/table.cpp
@@ -92,9 +92,10 @@ int MainWindow::Table_FileCount_reload()
         //Show or hide each list based on its file count
         //===============================================
         int TableView_VisibleCount = 0;
-        if (ui->label_DropFile) { // Check if the pointer is valid
-            ui->label_DropFile->setVisible(false); // Hide when there are files
-        }
+        // Drop-file label has been removed from the UI
+        // if (ui->label_DropFile) {
+        //     ui->label_DropFile->setVisible(false);
+        // }
         if(filecount_image>0)
         {
             ui->tableView_image->setVisible(1);
@@ -150,9 +151,10 @@ int MainWindow::Table_FileCount_reload()
         //====================
         //Hide file lists and clear selection
         //====================
-        if (ui->label_DropFile) { // Check if the pointer is valid
-            ui->label_DropFile->setVisible(true); // Show when no files are present
-        }
+        // Drop-file label has been removed from the UI
+        // if (ui->label_DropFile) {
+        //     ui->label_DropFile->setVisible(true);
+        // }
         curRow_image = -1;
         ui->tableView_image->clearSelection();
         ui->tableView_image->setVisible(0);

--- a/logs/2025-06-18T085232Z_build.log
+++ b/logs/2025-06-18T085232Z_build.log
@@ -1,0 +1,9 @@
+Current directory: /workspace/Beya_Waifu/Waifu2x-Extension-QT
+Locating qmake...
+Using QMAKE_CMD: qmake6
+QMake version 3.1
+Using Qt version 6.4.2 in /usr/lib/x86_64-linux-gnu
+Checking Qt dependencies...
+Missing Qt packages: qt6-multimedia-dev qt6-5compat-dev
+Install them using:
+sudo apt install qt6-multimedia-dev qt6-5compat-dev

--- a/logs/2025-06-18T085232Z_build_windows.log
+++ b/logs/2025-06-18T085232Z_build_windows.log
@@ -1,0 +1,1 @@
+bash: pwsh: command not found

--- a/logs/2025-06-18T085232Z_pip.log
+++ b/logs/2025-06-18T085232Z_pip.log
@@ -1,0 +1,32 @@
+Collecting Pillow>=10.0 (from -r requirements.txt (line 1))
+  Downloading pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (8.9 kB)
+Requirement already satisfied: pytest in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 2)) (8.3.5)
+Collecting pytest-subtests (from -r requirements.txt (line 3))
+  Downloading pytest_subtests-0.14.2-py3-none-any.whl.metadata (6.0 kB)
+Collecting PySide6 (from -r requirements.txt (line 4))
+  Downloading PySide6-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl.metadata (5.3 kB)
+Requirement already satisfied: iniconfig in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from pytest->-r requirements.txt (line 2)) (2.1.0)
+Requirement already satisfied: packaging in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from pytest->-r requirements.txt (line 2)) (25.0)
+Requirement already satisfied: pluggy<2,>=1.5 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from pytest->-r requirements.txt (line 2)) (1.6.0)
+Collecting attrs>=19.2.0 (from pytest-subtests->-r requirements.txt (line 3))
+  Downloading attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
+Collecting shiboken6==6.9.1 (from PySide6->-r requirements.txt (line 4))
+  Downloading shiboken6-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl.metadata (2.4 kB)
+Collecting PySide6-Essentials==6.9.1 (from PySide6->-r requirements.txt (line 4))
+  Downloading PySide6_Essentials-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl.metadata (3.6 kB)
+Collecting PySide6-Addons==6.9.1 (from PySide6->-r requirements.txt (line 4))
+  Downloading PySide6_Addons-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl.metadata (4.0 kB)
+Downloading pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl (4.6 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.6/4.6 MB 30.5 MB/s eta 0:00:00
+Downloading pytest_subtests-0.14.2-py3-none-any.whl (9.1 kB)
+Downloading PySide6-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl (558 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 558.2/558.2 kB 39.8 MB/s eta 0:00:00
+Downloading PySide6_Addons-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl (166.7 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 166.7/166.7 MB 39.9 MB/s eta 0:00:00
+Downloading PySide6_Essentials-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl (96.4 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.4/96.4 MB 36.2 MB/s eta 0:00:00
+Downloading shiboken6-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl (206 kB)
+Downloading attrs-25.3.0-py3-none-any.whl (63 kB)
+Installing collected packages: shiboken6, Pillow, attrs, pytest-subtests, PySide6-Essentials, PySide6-Addons, PySide6
+
+Successfully installed Pillow-11.2.1 PySide6-6.9.1 PySide6-Addons-6.9.1 PySide6-Essentials-6.9.1 attrs-25.3.0 pytest-subtests-0.14.2 shiboken6-6.9.1

--- a/logs/2025-06-18T085232Z_pytest.log
+++ b/logs/2025-06-18T085232Z_pytest.log
@@ -1,0 +1,2 @@
+ssssssssssssssssssssssssssssssssssssss.............s......sss            [100%]
+19 passed, 42 skipped in 8.68s

--- a/memory/archival/2025-06-18T085248Z-drop-file-label-removal.md
+++ b/memory/archival/2025-06-18T085248Z-drop-file-label-removal.md
@@ -1,0 +1,11 @@
+# Memory: Drop-file label references removed
+
+Today I removed the dynamic relayout block in `mainwindow.cpp` and commented out
+all remaining uses of `label_DropFile` in `table.cpp`. Build attempts via
+`simple_build.sh` failed due to missing Qt packages, and `build_windows.ps1`
+could not run because PowerShell was unavailable. After installing the Python
+requirements, all tests passed (19 passed, 42 skipped).
+
+Related memories:
+- [Initial Directories](2025-06-18-initial-directories.md)
+- [Follow AGENTS Instructions](2025-06-18-run-tests-patch-agents.md)


### PR DESCRIPTION
## Summary
- remove dynamic image tab re-layout in `mainwindow.cpp`
- comment out all uses of `label_DropFile` in `table.cpp`
- add corresponding memory entry
- include logs for build/test attempts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `bash ./simple_build.sh` *(fails: missing Qt packages)*
- `pwsh ./build_windows.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68527d26fdf08322a207221b05e39dde