### PR TITLE
Add safety checks for LiquidGlassWidget OpenGL init

### DIFF
--- a/memory/archival/2025-06-18T091029Z-liquidglass-openGL.md
+++ b/memory/archival/2025-06-18T091029Z-liquidglass-openGL.md
@@ -1,0 +1,12 @@
+# Memory: LiquidGlass OpenGL initialization check
+
+Implemented validation of OpenGL setup in `LiquidGlassWidget::initializeGL`.
+The widget now checks that `initializeOpenGLFunctions()` succeeds and that a
+3.3 context is available. If initialization or shader compilation/linking fails,
+the widget logs a `qWarning()` and disables itself to avoid invalid OpenGL use.
+All tests pass after installing dependencies and ensuring libEGL is present.
+
+Related memories:
+- [Initial Directories](2025-06-18-initial-directories.md)
+- [Follow AGENTS Instructions](2025-06-18-run-tests-patch-agents.md)
+- [Drop-file label references removed](2025-06-18T085248Z-drop-file-label-removal.md)


### PR DESCRIPTION
## Summary
- check OpenGL function init and context version in `LiquidGlassWidget::initializeGL`
- disable widget if initialization or shader program setup fails
- record memory of the new initialization logic

## Testing
- `pip install -r requirements.txt`
- `apt-get install -y libegl1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685281b4044883228f8d92b5a2f045a0