### PR TITLE
Fix Anime4K HDN spin box toggle

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -1171,9 +1171,8 @@ void MainWindow::on_checkBox_HDNMode_Anime4k_stateChanged(int arg1)
     if(isChecked && ui->checkBox_ACNet_Anime4K){ // If ACNet checkbox exists
         ui->checkBox_ACNet_Anime4K->setChecked(false); // ACNet and HDN might be mutually exclusive
     }
-    // Enable/disable HDN level spinbox
-    // if(ui->spinBox_HDNLevel_Anime4k) ui->spinBox_HDNLevel_Anime4k->setEnabled(isChecked);
-    // TODO: spinBox_HDNLevel_Anime4k not found in UI. Related control might be ui->spinBox_Passes_Anime4K or was removed.
+    // Enable/disable passes spin box
+    if(ui->spinBox_Passes_Anime4K) ui->spinBox_Passes_Anime4K->setEnabled(isChecked);
     qDebug() << "Anime4K HDN Mode state changed:" << arg1;
 }
 

--- a/memory/archival/2025-06-18T195718Z-hdn-passes-fix.md
+++ b/memory/archival/2025-06-18T195718Z-hdn-passes-fix.md
@@ -1,0 +1,7 @@
+# Memory: Anime4K HDN passes enable fix
+
+Today I replaced the outdated `spinBox_HDNLevel_Anime4k` logic in `mainwindow.cpp` with `spinBox_Passes_Anime4K`. Now the passes spin box is enabled or disabled when the HDN checkbox changes. All tests pass (`pytest -q`).
+
+Related memories:
+- [Follow AGENTS Instructions](2025-06-18-run-tests-patch-agents.md)
+- [Drop-file label references removed](2025-06-18T085248Z-drop-file-label-removal.md)


### PR DESCRIPTION
## Summary
- toggle `spinBox_Passes_Anime4K` when HDN mode changes
- add archival memory note

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68531919522883229c615634f78f1cb9