### PR TITLE
Add active threads label

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -2143,10 +2143,9 @@ void MainWindow::CheckIfAllFinished()
 
 void MainWindow::UpdateNumberOfActiveThreads()
 {
-    // if (ui->label_NumThreadsActive) { // Check if the UI element exists
-    //     ui->label_NumThreadsActive->setText(QString::number(ThreadNumRunning.load())); // ThreadNumRunning is std::atomic
-    // }
-    // TODO: label_NumThreadsActive not found in UI. This info might need a new display element.
+    if (ui->label_NumThreadsActive) {
+        ui->label_NumThreadsActive->setText(QString::number(ThreadNumRunning.load()));
+    }
 }
 
 void MainWindow::UpdateProgressBar()

--- a/Waifu2x-Extension-QT/mainwindow.ui
+++ b/Waifu2x-Extension-QT/mainwindow.ui
@@ -3502,21 +3502,54 @@ process at the same time.</string>
              </widget>
             </item>
             <item row="0" column="0">
-             <spacer name="horizontalSpacer_29">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
+            <spacer name="horizontalSpacer_29">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="0">
+            <spacer name="horizontalSpacer_49">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_NumThreadsActive">
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <spacer name="horizontalSpacer_50">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
          <item row="0" column="0">
           <widget class="QGroupBox" name="groupBox_Engine">
            <property name="minimumSize">


### PR DESCRIPTION
## Summary
- add `label_NumThreadsActive` below thread count inputs
- update `UpdateNumberOfActiveThreads()` to populate the new label

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853282b9f4c8322bb2db6d247acc48e