### PR TITLE
Reset compatibility test progress bar

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -2477,21 +2477,27 @@ QString MainWindow::Seconds2hms(long unsigned int seconds)
 
 void MainWindow::Finish_progressBar_CompatibilityTest()
 {
-    qDebug() << "STUB: MainWindow::Finish_progressBar_CompatibilityTest() called.";
-    if (ui->progressBar_CompatibilityTest) { // Check if UI element exists
+    qDebug() << "MainWindow::Finish_progressBar_CompatibilityTest() called.";
+
+    if (ui->progressBar_CompatibilityTest) {
         ui->progressBar_CompatibilityTest->setValue(ui->progressBar_CompatibilityTest->maximum());
         ui->progressBar_CompatibilityTest->setFormat(tr("Compatibility Test Finished"));
+
+        // Reset and hide the progress bar after the test
+        ui->progressBar_CompatibilityTest->setValue(0);
+        ui->progressBar_CompatibilityTest->setVisible(false);
     }
-    // Potentially enable the test button again
-    // if (ui->pushButton_compatibilityTest) {
-    //     ui->pushButton_compatibilityTest->setEnabled(true);
-    //     ui->pushButton_compatibilityTest->setText(tr("Compatibility Test"));
-    // }
+
+    // Re-enable the test button for future runs
+    if (ui->pushButton_compatibilityTest) {
+        ui->pushButton_compatibilityTest->setEnabled(true);
+        ui->pushButton_compatibilityTest->setText(tr("Start compatibility test"));
+    }
 }
 
 void MainWindow::TurnOffScreen()
 {
-    qDebug() << "STUB: MainWindow::TurnOffScreen() called.";
+    qDebug() << "MainWindow::TurnOffScreen() called.";
 #ifdef Q_OS_WIN
     // Simulate turning off the screen by sending SC_MONITORPOWER command
     // HWND_BROADCAST can be problematic. Prefer getting the top-level window handle.

--- a/memory/archival/2025-06-18T213809Z-compat-test-progress-reset.md
+++ b/memory/archival/2025-06-18T213809Z-compat-test-progress-reset.md
@@ -1,0 +1,7 @@
+# Memory: Compatibility test progress bar resets
+
+Implemented cleanup logic for `Finish_progressBar_CompatibilityTest()` so the progress bar resets to zero, hides itself, and the test button becomes active again. Removed placeholder "STUB" debug messages.
+
+Related memories:
+- [Anime4K HDN passes enable fix](2025-06-18T195718Z-hdn-passes-fix.md)
+- [Notification sound implemented](2025-06-18T211603Z-sound-notification.md)


### PR DESCRIPTION
## Summary
- reset and hide `progressBar_CompatibilityTest` when the test completes
- re-enable the compatibility test button after finishing
- remove `STUB` debug statements
- add memory note about the change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685330983138832297dbff8894cc239a