### PR TITLE
Implement TurnOffScreen for Windows

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -25,6 +25,9 @@ Copyright (C) 2025  beyawnko
 #include "GpuManager.h"
 #include "UiController.h"
 #include "LiquidGlassWidget.h"
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
 #include <QGridLayout>
 #include <QCheckBox>
 #include <QApplication>
@@ -2499,13 +2502,9 @@ void MainWindow::TurnOffScreen()
 {
     qDebug() << "MainWindow::TurnOffScreen() called.";
 #ifdef Q_OS_WIN
-    // Simulate turning off the screen by sending SC_MONITORPOWER command
-    // HWND_BROADCAST can be problematic. Prefer getting the top-level window handle.
-    // SendMessage(GetConsoleWindow(), WM_SYSCOMMAND, SC_MONITORPOWER, (LPARAM)2); // 2 = off, 1 = low power, -1 = on
-    // For a GUI app, you might need to find the main window's handle or use a different approach.
-    // This is a placeholder, proper implementation for screen off is platform-specific and complex.
-    qDebug() << "Screen off functionality is platform-specific and not fully implemented in this stub.";
+    // Turn off the monitor by broadcasting the SC_MONITORPOWER command
+    SendMessage(HWND_BROADCAST, WM_SYSCOMMAND, SC_MONITORPOWER, 2);
 #else
-    qDebug() << "Screen off functionality not implemented for this OS in this stub.";
+    qDebug() << "Turn off screen feature is not available on this platform.";
 #endif
 }

--- a/logs/2025-06-18T215617Z.log
+++ b/logs/2025-06-18T215617Z.log
@@ -1,0 +1,1 @@
+Implemented screen off; tests pass

--- a/memory/archival/2025-06-18T215543Z-turn-off-screen.md
+++ b/memory/archival/2025-06-18T215543Z-turn-off-screen.md
@@ -1,0 +1,7 @@
+# Memory: Windows screen off
+
+Implemented `TurnOffScreen()` in `mainwindow.cpp` using the Windows API `SendMessage(HWND_BROADCAST, WM_SYSCOMMAND, SC_MONITORPOWER, 2)` to power off monitors. Added conditional `windows.h` include. Non-Windows platforms now log that the feature isn't available.
+
+Related memories:
+- [Anime4K HDN passes enable fix](2025-06-18T195718Z-hdn-passes-fix.md)
+- [Compatibility test progress bar resets](2025-06-18T213809Z-compat-test-progress-reset.md)

--- a/memory/conversational/2025-06-18-session-summary.md
+++ b/memory/conversational/2025-06-18-session-summary.md
@@ -1,3 +1,5 @@
 # Conversation Summary (2025-06-18)
 
 The user requested the agent to follow instructions from `AGENTS.md`. The agent ran tests, installed dependencies, patched `AGENTS.md` to clarify setup steps, and created memory and log files accordingly.
+
+Implemented screen-off feature for Windows with SendMessage; tests passed.


### PR DESCRIPTION
## Summary
- power off monitors on Windows using the Win32 API
- add conditional windows.h include
- document the change in the memory system and conversation summary
- add execution log

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853350fce508322ab6c9c4b4d468186