### PR TITLE
Remove unused compatibility test init declaration

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -488,7 +488,6 @@ public:
     int Waifu2x_Compatibility_Test();
     int Simple_Compatibility_Test();
     void waitForCompatibilityTest();
-    void Init_progressBar_CompatibilityTest();
     void Finish_progressBar_CompatibilityTest();
     bool isCompatible_RealCUGAN_NCNN_Vulkan=false;
     bool isCompatible_RealESRGAN_NCNN_Vulkan=false;

--- a/memory/archival/2025-06-18T223304Z-remove-init-progressbar.md
+++ b/memory/archival/2025-06-18T223304Z-remove-init-progressbar.md
@@ -1,0 +1,7 @@
+# Memory: Remove compatibility test progress bar init declaration
+
+Deleted the unused `Init_progressBar_CompatibilityTest()` declaration from `mainwindow.h`. No definition or calls existed, so the removal cleans up dead code. All tests pass (`pytest -q`).
+
+Related memories:
+- [Compatibility test progress bar resets](2025-06-18T213809Z-compat-test-progress-reset.md)
+- [Anime4K HDN passes enable fix](2025-06-18T195718Z-hdn-passes-fix.md)


### PR DESCRIPTION
## Summary
- remove the unused `Init_progressBar_CompatibilityTest` declaration
- record memory about removing unused progress bar initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533df069d083229ebdc4ecaf72af5a