### PR TITLE
Enhance compatibility test progress bar

### DIFF
--- a/Waifu2x-Extension-QT/CompatibilityTest.cpp
+++ b/Waifu2x-Extension-QT/CompatibilityTest.cpp
@@ -4,6 +4,11 @@
 void MainWindow::on_pushButton_compatibilityTest_clicked()
 {
     ui->pushButton_compatibilityTest->setEnabled(false);
+    if (ui->progressBar_CompatibilityTest) {
+        ui->progressBar_CompatibilityTest->setRange(0, 2);
+        ui->progressBar_CompatibilityTest->setValue(0);
+        ui->progressBar_CompatibilityTest->setVisible(true);
+    }
     compatibilityTestFuture = QtConcurrent::run([this]() {
         this->Simple_Compatibility_Test();
     });
@@ -13,8 +18,14 @@ int MainWindow::Simple_Compatibility_Test()
 {
     QString realcuganExe = Current_Path + "/realcugan-ncnn-vulkan/realcugan-ncnn-vulkan.exe";
     QString realesrganExe = Current_Path + "/realesrgan-ncnn-vulkan/realesrgan-ncnn-vulkan.exe";
+
     isCompatible_RealCUGAN_NCNN_Vulkan = QFile::exists(realcuganExe);
+    emit Send_Add_progressBar_CompatibilityTest();
+
     isCompatible_RealESRGAN_NCNN_Vulkan = QFile::exists(realesrganExe);
+    emit Send_Add_progressBar_CompatibilityTest();
+
+    QMetaObject::invokeMethod(this, "Finish_progressBar_CompatibilityTest", Qt::QueuedConnection);
     emit Send_Waifu2x_Compatibility_Test_finished();
     return 0;
 }

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -66,6 +66,11 @@ MainWindow::MainWindow(int maxThreadsOverride, QWidget *parent)
 {
     ui->setupUi(this);
 
+    connect(this,
+            &MainWindow::Send_Add_progressBar_CompatibilityTest,
+            this,
+            &MainWindow::Add_progressBar_CompatibilityTest);
+
     /*
      * Disabled block that previously re-parented the first image tab's table and
      * inserted a new layout with a title label. The application no longer

--- a/memory/archival/2025-06-18T232724Z-compat-test-progress-bar.md
+++ b/memory/archival/2025-06-18T232724Z-compat-test-progress-bar.md
@@ -1,0 +1,7 @@
+# Memory: Compatibility test progress updates
+
+Added progress tracking to the simple compatibility test. The UI progress bar now initializes to two steps when the test begins and increments after checking for RealCUGAN and RealESRGAN executables. The bar finishes and hides once tests complete.
+
+Related memories:
+- [Compatibility test progress bar resets](2025-06-18T213809Z-compat-test-progress-reset.md)
+- [Remove compatibility progress init](2025-06-18T223304Z-remove-init-progressbar.md)


### PR DESCRIPTION
## Summary
- increment progress bar when checking RealCUGAN and RealESRGAN
- initialize the bar and show it when starting the test
- connect progress signal during window setup
- add memory entry on compatibility test progress handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853494099f483229d76dfd9cf8c0374