### PR TITLE
Add Qt style fallback logic

### DIFF
--- a/Waifu2x-Extension-QT-Launcher/main.cpp
+++ b/Waifu2x-Extension-QT-Launcher/main.cpp
@@ -6,7 +6,11 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc,argv);
-    a.setStyle(QStyleFactory::create("macos"));
+    QStyle *style = QStyleFactory::create("macos");
+    if (!style)
+        style = QStyleFactory::create("Fusion");
+    if (style)
+        a.setStyle(style);
     MainWindow *w = new MainWindow(0);
     w->show();
     return a.exec();

--- a/Waifu2x-Extension-QT/main.cpp
+++ b/Waifu2x-Extension-QT/main.cpp
@@ -29,7 +29,11 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
-    a.setStyle(QStyleFactory::create("macos"));
+    QStyle *style = QStyleFactory::create("macos");
+    if (!style)
+        style = QStyleFactory::create("Fusion");
+    if (style)
+        a.setStyle(style);
 
     QDir logDir(QCoreApplication::applicationDirPath() + "/logs");
     if (!logDir.exists())

--- a/memory/archival/2025-06-19T015431Z-style-fallback.md
+++ b/memory/archival/2025-06-19T015431Z-style-fallback.md
@@ -1,0 +1,10 @@
+# Qt Style Fallback Logic
+
+## Summary
+- Replaced unconditional style initialization with fallback logic in both main executables.
+- Added a PySide6 test ensuring QApplication::style is not null when applying this logic.
+- All existing tests including the new one pass.
+
+## Related
+- [2025-06-18T215543Z-turn-off-screen.md](2025-06-18T215543Z-turn-off-screen.md)
+- [2025-06-19T011114Z-contrib-tests.md](2025-06-19T011114Z-contrib-tests.md)

--- a/tests/test_qstyle_fallback.py
+++ b/tests/test_qstyle_fallback.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+from tests import PYSIDE6_AVAILABLE
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+if not PYSIDE6_AVAILABLE:
+    pytest.skip("PySide6 not available", allow_module_level=True)
+
+from PySide6.QtWidgets import QApplication, QStyleFactory
+
+def test_qstyle_fallback():
+    app = QApplication.instance() or QApplication([])
+    style = QStyleFactory.create("macos")
+    if not style:
+        style = QStyleFactory.create("Fusion")
+    if style:
+        app.setStyle(style)
+    assert QApplication.style() is not None


### PR DESCRIPTION
## Summary
- add fallback style logic when macOS style missing
- test fallback logic via PySide6
- record work in memory

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536d24c9088322af4565b3304c3fd2