### PR TITLE
Document and handle LiquidGlass shader build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,11 @@ Thank you for considering a contribution! Please follow these steps when prepari
    ```bash
    pip install -r requirements.txt
    ```
-3. Execute the tests from the repository root:
+3. Generate the Liquid Glass shader if `shaders/liquidglass.frag.qsb` is missing:
+   ```bash
+   ./tools/build_liquidglass_shader.sh
+   ```
+4. Execute the tests from the repository root:
    ```bash
    pytest
    ```

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ Run the application with `--verbose` to capture detailed logs in `logs/waifu.log
 The application ships with an experimental Liquid Glass shader that creates a refractive glass sphere from the scene
 behind it. Building this effect requires the `qsb` tool provided by Qt 6. The `Waifu2x-Extension-QT.pro` file runs `qsb`
 automatically and writes `shaders/liquidglass.frag.qsb`. Ensure the tool is available in `PATH` when invoking `qmake`.
+If you cloned the repository without build artifacts, create this file manually using `qsb`:
+
+```bash
+./tools/build_liquidglass_shader.sh
+```
 The Liquid Glass shader parameters (resolution, time, mouse, IOR, etc.) are now passed via a Uniform Buffer Object (UBO).
 This change in `liquidglass.frag` requires corresponding setup in `LiquidGlassWidget.cpp` to define, populate, and bind this UBO.
 
@@ -363,8 +368,8 @@ Below is the start-up screen of the optional launcher:
   [Real-ESRGAN](https://github.com/xinntao/Real-ESRGAN) documentation for detailed usage and model descriptions.
 - Install the packages from `requirements.txt` before running `pytest` or you will encounter `ImportError` messages for
   modules such as `PySide6` and `Pillow`.
-- When `simple_build.sh` fails with errors about `*.qsb` files, install the Qt 6 shader tools package:
-  `sudo apt install qt6-shadertools-dev`.
+  - When `simple_build.sh` or the GUI tests fail with errors about `*.qsb` files, install the Qt 6 shader tools package and
+    regenerate `shaders/liquidglass.frag.qsb` using `./tools/build_liquidglass_shader.sh`.
 
 ## Tests
 
@@ -376,6 +381,12 @@ Install the packages listed in `requirements.txt` before running `pytest`:
 
 ```bash
 pip install -r requirements.txt
+```
+
+If `tests/test_qml_liquidglass.py` warns that `shaders/liquidglass.frag.qsb` is missing, run:
+
+```bash
+./tools/build_liquidglass_shader.sh
 ```
 
 `PySide6` and `Pillow` are required, and missing either will cause `ImportError` failures in the tests. The suite

--- a/memory/archival/2025-06-19T022947Z-liquidglass-qsb-docs.md
+++ b/memory/archival/2025-06-19T022947Z-liquidglass-qsb-docs.md
@@ -1,0 +1,10 @@
+# LiquidGlass Shader Build Instructions
+
+## Summary
+- Documented that `shaders/liquidglass.frag.qsb` must be generated with `qsb` before building or running GUI tests.
+- Added `tools/build_liquidglass_shader.sh` to compile the shader.
+- Tests now skip the Liquid Glass QML test when the `.qsb` file is absent.
+
+## Related
+- [2025-06-19T011114Z-contrib-tests.md](2025-06-19T011114Z-contrib-tests.md)
+- [2025-06-19T015431Z-style-fallback.md](2025-06-19T015431Z-style-fallback.md)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 """Test package initialization."""
 import warnings
+from pathlib import Path
 
 try:
     import PySide6  # noqa: F401  # type: ignore
@@ -9,4 +10,16 @@ except Exception:
     warnings.warn(
         "PySide6 could not be imported. GUI tests will be skipped."
         " Install it via 'pip install -r requirements.txt' to run them."
+    )
+
+LIQUIDGLASS_QSB = (
+    Path(__file__).resolve().parents[1]
+    / "Waifu2x-Extension-QT"
+    / "shaders"
+    / "liquidglass.frag.qsb"
+)
+LIQUIDGLASS_QSB_AVAILABLE = LIQUIDGLASS_QSB.exists()
+if not LIQUIDGLASS_QSB_AVAILABLE:
+    warnings.warn(
+        "Missing shaders/liquidglass.frag.qsb. Liquid Glass tests will be skipped."
     )

--- a/tests/test_qml_liquidglass.py
+++ b/tests/test_qml_liquidglass.py
@@ -2,9 +2,11 @@ import os
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 from pathlib import Path
 import pytest
-from tests import PYSIDE6_AVAILABLE
+from tests import PYSIDE6_AVAILABLE, LIQUIDGLASS_QSB_AVAILABLE
 if not PYSIDE6_AVAILABLE:
     pytest.skip("PySide6 not available", allow_module_level=True)
+if not LIQUIDGLASS_QSB_AVAILABLE:
+    pytest.skip("liquidglass.frag.qsb not built", allow_module_level=True)
 from PySide6.QtCore import QUrl
 from PySide6.QtQml import QQmlEngine, QQmlComponent
 from PySide6.QtWidgets import QApplication

--- a/tools/build_liquidglass_shader.sh
+++ b/tools/build_liquidglass_shader.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SHADER="$REPO_ROOT/Waifu2x-Extension-QT/shaders/liquidglass.frag"
+OUTPUT="$REPO_ROOT/Waifu2x-Extension-QT/shaders/liquidglass.frag.qsb"
+
+if ! command -v qsb >/dev/null; then
+    echo "Error: qsb not found in PATH. Install the Qt shader tools package." >&2
+    exit 1
+fi
+
+qsb "$SHADER" -o "$OUTPUT"
+echo "Generated $OUTPUT"


### PR DESCRIPTION
## Summary
- mention manual qsb compilation in README
- update contributing guide to run `build_liquidglass_shader.sh`
- check for shader in tests and skip when missing
- provide helper script to build the shader
- add memory note about shader build requirement

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853754678348322bf91118f9d094ea5