### PR TITLE
Improve UI load test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pillow>=10.0
 pytest
 pytest-subtests
 PySide6
+lxml


### PR DESCRIPTION
## Summary
- load `mainwindow.ui` even if malformed using lxml recovery
- test for additional widgets (FrameInterpolation/InputExt)
- assert Qt runs in offscreen mode
- require lxml in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685468edd7dc832281e14f3c0bd22911