### PR TITLE
Fix: Compile and include LiquidGlass shader

### DIFF
--- a/tools/build_liquidglass_shader.sh
+++ b/tools/build_liquidglass_shader.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 set -e
 
-SCRIPT_DIR="$(dirname "$0")"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SHADER="$REPO_ROOT/Waifu2x-Extension-QT/shaders/liquidglass.frag"
-OUTPUT="$REPO_ROOT/Waifu2x-Extension-QT/shaders/liquidglass.frag.qsb"
+# Determine the repository root using git
+REPO_ROOT=$(git rev-parse --show-toplevel)
 
-if ! command -v qsb >/dev/null; then
-    echo "Error: qsb not found in PATH. Install the Qt shader tools package." >&2
+if [ -z "$REPO_ROOT" ]; then
+    echo "Error: Could not determine repository root. Make sure you are in a git repository." >&2
     exit 1
 fi
 
-qsb "$SHADER" -o "$OUTPUT"
-echo "Generated $OUTPUT"
+SHADER_PATH="$REPO_ROOT/Waifu2x-Extension-QT/shaders/liquidglass.frag"
+OUTPUT_PATH="$REPO_ROOT/Waifu2x-Extension-QT/shaders/liquidglass.frag.qsb"
+
+QSB_BIN="/usr/lib/qt6/bin/qsb"
+
+if [ ! -f "$QSB_BIN" ]; then
+    echo "Error: qsb not found at $QSB_BIN. Please ensure qt6-shader-baker is installed correctly." >&2
+    exit 1
+fi
+
+"$QSB_BIN" "$SHADER_PATH" -o "$OUTPUT_PATH"
+echo "Generated $OUTPUT_PATH"


### PR DESCRIPTION
- Updated tools/build_liquidglass_shader.sh to correctly find and use the qsb (Qt Shader Baker) tool by using an absolute path found via dpkg and ensuring qt6-shader-baker is installed.
- Generated Waifu2x-Extension-QT/shaders/liquidglass.frag.qsb.
- Verified that tests/test_qml_liquidglass.py now passes as the shader is available.

Note: shaders.qrc already contained the entry for liquidglass.frag.qsb, so no changes were needed there.