### PR TITLE
Fix: Address build errors from Qt UI compiler and C++ issues

### DIFF
--- a/Waifu2x-Extension-QT/Frame_Interpolation.cpp
+++ b/Waifu2x-Extension-QT/Frame_Interpolation.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Aaron Feng
+Copyright (C) 2025  beyawnko
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -14,8 +14,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    My Github homepage: https://github.com/AaronFeng753
+    My Github homepage: https://github.com/beyawnko
 */
+
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include <QEventLoop>
@@ -553,7 +554,7 @@ bool MainWindow::FrameInterpolation(QString SourcePath,QString OutputPath)
         //=======
         // Default retry count to 1 as spinBox_retry was removed.
         // The retry_add logic was also removed.
-        for(int retry=0; retry < 1; retry++) // ui->spinBox_retry->value() replaced with 1
+        for(int retry=0; retry < 1; retry++) // 1 replaced with 1
         {
             FrameInterpolation_QProcess_failed = false;
             ErrorMSG="";

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -992,7 +992,7 @@ void MainWindow::on_pushButton_CustRes_cancel_clicked()
 void MainWindow::comboBox_UpdateChannel_setCurrentIndex_self(int index)
 {
     QMutexLocker locker(&comboBox_UpdateChannel_setCurrentIndex_self_QMutex);
-    // ui->comboBox_UpdateChannel was removed. This function is now a no-op.
+//     // ui->comboBox_UpdateChannel was removed. This function is now a no-op.
     // Consider removing calls to this function if it's no longer needed.
     Q_UNUSED(index);
     qDebug() << "comboBox_UpdateChannel_setCurrentIndex_self called, but comboBox_UpdateChannel was removed.";
@@ -1000,7 +1000,7 @@ void MainWindow::comboBox_UpdateChannel_setCurrentIndex_self(int index)
 
 void MainWindow::on_comboBox_language_currentIndexChanged(int index)
 {
-    // QString lang = ui->comboBox_language->itemData(index).toString(); // comboBox_language removed
+//     // QString lang = ui->comboBox_language->itemData(index).toString(); // comboBox_language removed
     // Defaulting to English ("en") as comboBox_language is no longer available.
     QString lang = "en";
     Q_UNUSED(index); // Index is no longer used directly
@@ -1034,7 +1034,7 @@ void MainWindow::on_comboBox_language_currentIndexChanged(int index)
 
     Settings_Save(); // Save the new language preference
     ui->retranslateUi(this); // Retranslate UI (though Qt does much of this automatically on changeEvent)
-    TextBrowser_NewMessage(tr("Language changed to %1. Restart recommended if not all elements updated.").arg(ui->comboBox_language->currentText()));
+//     TextBrowser_NewMessage(tr("Language changed to %1. Restart recommended if not all elements updated.").arg(ui->comboBox_language->currentText()));
 }
 
 void MainWindow::on_pushButton_about_clicked()
@@ -1933,7 +1933,7 @@ void MainWindow::on_comboBox_UpdateChannel_currentIndexChanged(int index)
     Q_UNUSED(index);
     Settings_Save(); // Save the selected update channel
     // Potentially trigger an immediate check for updates or change how updates are fetched
-    qDebug() << "Update channel changed. Index:" << index << "Channel:" << ui->comboBox_UpdateChannel->currentText();
+//     qDebug() << "Update channel changed. Index:" << index << "Channel:" << ui->comboBox_UpdateChannel->currentText();
 }
 
 // Compatibility Checkbox Implementations

--- a/Waifu2x-Extension-QT/mainwindow.ui
+++ b/Waifu2x-Extension-QT/mainwindow.ui
@@ -1605,7 +1605,7 @@ padding:0px;
                 <string/>
                </property>
                <property name="class">
-               <string>blue</string>
+                <string>blue</string>
                </property>
                <property name="text">
                 <string>Hide settings</string>

--- a/WinBuildErrorLog.md
+++ b/WinBuildErrorLog.md
@@ -1,22 +1,13 @@
 /usr/lib/qt6/libexec/uic mainwindow.ui -o ui_mainwindow.h
-/usr/lib/qt6/libexec/uic topsupporterslist.ui -o ui_topsupporterslist.h
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o VideoProcessor.o VideoProcessor.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o RealcuganJobManager.o RealcuganJobManager.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o FileManager.o FileManager.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o ProcessRunner.o ProcessRunner.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o LiquidGlassWidget.o LiquidGlassWidget.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o GpuManager.o GpuManager.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o UiController.o UiController.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o Logger.o Logger.cpp
-/usr/lib/qt6/libexec/rcc -name OtherPic OtherPic.qrc -o qrc_OtherPic.cpp
-/usr/lib/qt6/libexec/rcc -name donate donate.qrc -o qrc_donate.cpp
-/usr/lib/qt6/libexec/rcc -name icon icon.qrc -o qrc_icon.cpp
-/usr/lib/qt6/libexec/rcc -name style style.qrc -o qrc_style.cpp
 /usr/lib/qt6/libexec/rcc -name shaders shaders.qrc -o qrc_shaders.cpp
-g++ -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -dM -E -o moc_predefs.h /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/data/dummy.cpp
+g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o qrc_shaders.o qrc_shaders.cpp
 g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o AnimatedPNG.o AnimatedPNG.cpp
+g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o CompatibilityTest.o CompatibilityTest.cpp
+g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o Current_File_Progress.o Current_File_Progress.cpp
+g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o CustomResolution.o CustomResolution.cpp
 In file included from UiController.h:9,
-                 from UiController.cpp:4:
+                 from mainwindow.h:58,
+                 from CompatibilityTest.cpp:1:
 ui_mainwindow.h: In member function ‘void Ui_MainWindow::retranslateUi(QMainWindow*)’:
 ui_mainwindow.h:5446:28: error: ‘class QPushButton’ has no member named ‘setClass’
  5446 |         pushButton_PayPal->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
@@ -57,9 +48,103 @@ ui_mainwindow.h:5951:59: error: ‘class QPushButton’ has no member named ‘s
 ui_mainwindow.h:5998:38: error: ‘class QPushButton’ has no member named ‘setClass’
  5998 |         pushButton_ListGPUs_Anime4k->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
       |                                      ^~~~~~~~
+In file included from UiController.h:9,
+                 from mainwindow.h:58,
+                 from Current_File_Progress.cpp:20:
+ui_mainwindow.h: In member function ‘void Ui_MainWindow::retranslateUi(QMainWindow*)’:
+ui_mainwindow.h:5446:28: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5446 |         pushButton_PayPal->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                            ^~~~~~~~
 ui_mainwindow.h:6013:46: error: ‘class QPushButton’ has no member named ‘setClass’
  6013 |         pushButton_VerifyGPUsConfig_Anime4k->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
       |                                              ^~~~~~~~
+ui_mainwindow.h:5450:29: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5450 |         pushButton_Patreon->setClass(QCoreApplication::translate("MainWindow", "red", nullptr));
+      |                             ^~~~~~~~
+ui_mainwindow.h:5464:27: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5464 |         pushButton_Start->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
+      |                           ^~~~~~~~
+ui_mainwindow.h:5466:26: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5466 |         pushButton_Stop->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                          ^~~~~~~~
+ui_mainwindow.h:5479:32: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5479 |         pushButton_ForceRetry->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                                ^~~~~~~~
+ui_mainwindow.h:6088:57: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6088 |         pushButton_ShowMultiGPUSettings_SrmdNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                                                         ^~~~~~~~
+ui_mainwindow.h:6096:38: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6096 |         pushButton_DetectGPUID_srmd->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                                      ^~~~~~~~
+ui_mainwindow.h:5553:34: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5553 |         pushButton_HideSettings->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                                  ^~~~~~~~
+ui_mainwindow.h:5555:33: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5555 |         pushButton_HideTextBro->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                                 ^~~~~~~~
+ui_mainwindow.h:5578:35: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5578 |         pushButton_CustRes_apply->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
+      |                                   ^~~~~~~~
+ui_mainwindow.h:6175:51: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6175 |         pushButton_VerifyGPUsConfig_Waifu2xCaffe->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                                                   ^~~~~~~~
+ui_mainwindow.h:5584:36: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5584 |         pushButton_CustRes_cancel->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                                    ^~~~~~~~
+ui_mainwindow.h:6232:48: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6232 |         pushButton_DetectGPU_RealsrNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                                                ^~~~~~~~
+ui_mainwindow.h:6256:63: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6256 |         pushButton_ShowMultiGPUSettings_RealesrganNcnnVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                                                               ^~~~~~~~
+ui_mainwindow.h:6338:35: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6338 |         pushButton_DetectGPU_VFI->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                                   ^~~~~~~~
+ui_mainwindow.h:6351:41: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6351 |         pushButton_Verify_MultiGPU_VFI->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                                         ^~~~~~~~
+ui_mainwindow.h:5848:31: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5848 |         pushButton_DetectGPU->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                               ^~~~~~~~
+ui_mainwindow.h:5878:60: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5878 |         pushButton_ShowMultiGPUSettings_Waifu2xNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                                                            ^~~~~~~~
+ui_mainwindow.h:6451:40: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6451 |         pushButton_ResetVideoSettings->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                                        ^~~~~~~~
+ui_mainwindow.h:6453:34: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6453 |         pushButton_encodersList->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                                  ^~~~~~~~
+ui_mainwindow.h:5951:59: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5951 |         pushButton_ShowMultiGPUSettings_Waifu2xConverter->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                                                           ^~~~~~~~
+ui_mainwindow.h:6521:41: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6521 |         pushButton_Save_GlobalFontSize->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
+      |                                         ^~~~~~~~
+ui_mainwindow.h:6529:34: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6529 |         pushButton_SaveSettings->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                                  ^~~~~~~~
+ui_mainwindow.h:6532:33: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6532 |         pushButton_CheckUpdate->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
+      |                                 ^~~~~~~~
+ui_mainwindow.h:5998:38: error: ‘class QPushButton’ has no member named ‘setClass’
+ 5998 |         pushButton_ListGPUs_Anime4k->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
+      |                                      ^~~~~~~~
+ui_mainwindow.h:6534:28: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6534 |         pushButton_Report->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
+      |                            ^~~~~~~~
+ui_mainwindow.h:6540:26: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6540 |         pushButton_wiki->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                          ^~~~~~~~
+ui_mainwindow.h:6013:46: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6013 |         pushButton_VerifyGPUsConfig_Anime4k->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
+      |                                              ^~~~~~~~
+ui_mainwindow.h:6542:27: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6542 |         pushButton_about->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
+      |                           ^~~~~~~~
+ui_mainwindow.h:6544:36: error: ‘class QPushButton’ has no member named ‘setClass’
+ 6544 |         pushButton_SupportersList->setClass(QCoreApplication::translate("MainWindow", "red", nullptr));
+      |                                    ^~~~~~~~
 ui_mainwindow.h:6088:57: error: ‘class QPushButton’ has no member named ‘setClass’
  6088 |         pushButton_ShowMultiGPUSettings_SrmdNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
       |                                                         ^~~~~~~~
@@ -108,10 +193,6 @@ ui_mainwindow.h:6542:27: error: ‘class QPushButton’ has no member named ‘s
 ui_mainwindow.h:6544:36: error: ‘class QPushButton’ has no member named ‘setClass’
  6544 |         pushButton_SupportersList->setClass(QCoreApplication::translate("MainWindow", "red", nullptr));
       |                                    ^~~~~~~~
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o CompatibilityTest.o CompatibilityTest.cpp
-g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_MULTIMEDIA_LIB -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CONCURRENT_LIB -DQT_NETWORK_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtMultimedia -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtOpenGL -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtNetwork -I/usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -o Current_File_Progress.o Current_File_Progress.cpp
-make: *** [Makefile:958: UiController.o] Error 1
-make: *** Waiting for unfinished jobs....
 In file included from UiController.h:9,
                  from mainwindow.h:58,
                  from AnimatedPNG.cpp:19:
@@ -208,7 +289,7 @@ ui_mainwindow.h:6544:36: error: ‘class QPushButton’ has no member named ‘s
       |                                    ^~~~~~~~
 In file included from UiController.h:9,
                  from mainwindow.h:58,
-                 from Current_File_Progress.cpp:20:
+                 from CustomResolution.cpp:20:
 ui_mainwindow.h: In member function ‘void Ui_MainWindow::retranslateUi(QMainWindow*)’:
 ui_mainwindow.h:5446:28: error: ‘class QPushButton’ has no member named ‘setClass’
  5446 |         pushButton_PayPal->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
@@ -300,100 +381,8 @@ ui_mainwindow.h:6542:27: error: ‘class QPushButton’ has no member named ‘s
 ui_mainwindow.h:6544:36: error: ‘class QPushButton’ has no member named ‘setClass’
  6544 |         pushButton_SupportersList->setClass(QCoreApplication::translate("MainWindow", "red", nullptr));
       |                                    ^~~~~~~~
-In file included from UiController.h:9,
-                 from mainwindow.h:58,
-                 from CompatibilityTest.cpp:1:
-ui_mainwindow.h: In member function ‘void Ui_MainWindow::retranslateUi(QMainWindow*)’:
-ui_mainwindow.h:5446:28: error: ‘class QPushButton’ has no member named ‘setClass’
- 5446 |         pushButton_PayPal->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                            ^~~~~~~~
-ui_mainwindow.h:5450:29: error: ‘class QPushButton’ has no member named ‘setClass’
- 5450 |         pushButton_Patreon->setClass(QCoreApplication::translate("MainWindow", "red", nullptr));
-      |                             ^~~~~~~~
-ui_mainwindow.h:5464:27: error: ‘class QPushButton’ has no member named ‘setClass’
- 5464 |         pushButton_Start->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
-      |                           ^~~~~~~~
-ui_mainwindow.h:5466:26: error: ‘class QPushButton’ has no member named ‘setClass’
- 5466 |         pushButton_Stop->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                          ^~~~~~~~
-ui_mainwindow.h:5479:32: error: ‘class QPushButton’ has no member named ‘setClass’
- 5479 |         pushButton_ForceRetry->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                                ^~~~~~~~
-ui_mainwindow.h:5553:34: error: ‘class QPushButton’ has no member named ‘setClass’
- 5553 |         pushButton_HideSettings->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                                  ^~~~~~~~
-ui_mainwindow.h:5555:33: error: ‘class QPushButton’ has no member named ‘setClass’
- 5555 |         pushButton_HideTextBro->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                                 ^~~~~~~~
-ui_mainwindow.h:5578:35: error: ‘class QPushButton’ has no member named ‘setClass’
- 5578 |         pushButton_CustRes_apply->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
-      |                                   ^~~~~~~~
-ui_mainwindow.h:5584:36: error: ‘class QPushButton’ has no member named ‘setClass’
- 5584 |         pushButton_CustRes_cancel->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                                    ^~~~~~~~
-ui_mainwindow.h:5848:31: error: ‘class QPushButton’ has no member named ‘setClass’
- 5848 |         pushButton_DetectGPU->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                               ^~~~~~~~
-ui_mainwindow.h:5878:60: error: ‘class QPushButton’ has no member named ‘setClass’
- 5878 |         pushButton_ShowMultiGPUSettings_Waifu2xNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                                                            ^~~~~~~~
-ui_mainwindow.h:5951:59: error: ‘class QPushButton’ has no member named ‘setClass’
- 5951 |         pushButton_ShowMultiGPUSettings_Waifu2xConverter->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                                                           ^~~~~~~~
-ui_mainwindow.h:5998:38: error: ‘class QPushButton’ has no member named ‘setClass’
- 5998 |         pushButton_ListGPUs_Anime4k->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
-      |                                      ^~~~~~~~
-ui_mainwindow.h:6013:46: error: ‘class QPushButton’ has no member named ‘setClass’
- 6013 |         pushButton_VerifyGPUsConfig_Anime4k->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                                              ^~~~~~~~
-ui_mainwindow.h:6088:57: error: ‘class QPushButton’ has no member named ‘setClass’
- 6088 |         pushButton_ShowMultiGPUSettings_SrmdNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                                                         ^~~~~~~~
-ui_mainwindow.h:6096:38: error: ‘class QPushButton’ has no member named ‘setClass’
- 6096 |         pushButton_DetectGPUID_srmd->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                                      ^~~~~~~~
-ui_mainwindow.h:6175:51: error: ‘class QPushButton’ has no member named ‘setClass’
- 6175 |         pushButton_VerifyGPUsConfig_Waifu2xCaffe->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                                                   ^~~~~~~~
-ui_mainwindow.h:6232:48: error: ‘class QPushButton’ has no member named ‘setClass’
- 6232 |         pushButton_DetectGPU_RealsrNCNNVulkan->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                                                ^~~~~~~~
-ui_mainwindow.h:6256:63: error: ‘class QPushButton’ has no member named ‘setClass’
- 6256 |         pushButton_ShowMultiGPUSettings_RealesrganNcnnVulkan->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                                                               ^~~~~~~~
-ui_mainwindow.h:6338:35: error: ‘class QPushButton’ has no member named ‘setClass’
- 6338 |         pushButton_DetectGPU_VFI->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                                   ^~~~~~~~
-ui_mainwindow.h:6351:41: error: ‘class QPushButton’ has no member named ‘setClass’
- 6351 |         pushButton_Verify_MultiGPU_VFI->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                                         ^~~~~~~~
-ui_mainwindow.h:6451:40: error: ‘class QPushButton’ has no member named ‘setClass’
- 6451 |         pushButton_ResetVideoSettings->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                                        ^~~~~~~~
-ui_mainwindow.h:6453:34: error: ‘class QPushButton’ has no member named ‘setClass’
- 6453 |         pushButton_encodersList->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                                  ^~~~~~~~
-ui_mainwindow.h:6521:41: error: ‘class QPushButton’ has no member named ‘setClass’
- 6521 |         pushButton_Save_GlobalFontSize->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
-      |                                         ^~~~~~~~
-ui_mainwindow.h:6529:34: error: ‘class QPushButton’ has no member named ‘setClass’
- 6529 |         pushButton_SaveSettings->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                                  ^~~~~~~~
-ui_mainwindow.h:6532:33: error: ‘class QPushButton’ has no member named ‘setClass’
- 6532 |         pushButton_CheckUpdate->setClass(QCoreApplication::translate("MainWindow", "green", nullptr));
-      |                                 ^~~~~~~~
-ui_mainwindow.h:6534:28: error: ‘class QPushButton’ has no member named ‘setClass’
- 6534 |         pushButton_Report->setClass(QCoreApplication::translate("MainWindow", "orange", nullptr));
-      |                            ^~~~~~~~
-ui_mainwindow.h:6540:26: error: ‘class QPushButton’ has no member named ‘setClass’
- 6540 |         pushButton_wiki->setClass(QCoreApplication::translate("MainWindow", "purple", nullptr));
-      |                          ^~~~~~~~
-ui_mainwindow.h:6542:27: error: ‘class QPushButton’ has no member named ‘setClass’
- 6542 |         pushButton_about->setClass(QCoreApplication::translate("MainWindow", "blue", nullptr));
-      |                           ^~~~~~~~
-ui_mainwindow.h:6544:36: error: ‘class QPushButton’ has no member named ‘setClass’
- 6544 |         pushButton_SupportersList->setClass(QCoreApplication::translate("MainWindow", "red", nullptr));
-      |                                    ^~~~~~~~
-make: *** [Makefile:680: AnimatedPNG.o] Error 1
-make: *** [Makefile:700: Current_File_Progress.o] Error 1
 make: *** [Makefile:690: CompatibilityTest.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [Makefile:700: Current_File_Progress.o] Error 1
+make: *** [Makefile:680: AnimatedPNG.o] Error 1
+make: *** [Makefile:710: CustomResolution.o] Error 1

--- a/apply_fixes.py
+++ b/apply_fixes.py
@@ -1,0 +1,143 @@
+import os
+import re
+
+# --- File Paths ---
+project_dir = 'Waifu2x-Extension-QT'
+ui_file = os.path.join(project_dir, 'mainwindow.ui')
+fi_cpp = os.path.join(project_dir, 'Frame_Interpolation.cpp')
+mw_cpp = os.path.join(project_dir, 'mainwindow.cpp')
+style_qrc = os.path.join(project_dir, 'style.qrc') # Assume the stylesheet is findable via the .qrc
+
+# --- Part 1: Fix the UI and Stylesheet definitively ---
+print(f"Patching {ui_file} to use a safe property name...")
+if os.path.exists(ui_file):
+    with open(ui_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+    # Replace all instances of styleClass with cssClass. This forces uic to use setProperty().
+    # Also, ensure any original 'class' properties are also caught and changed to 'cssClass'.
+    content = re.sub(r'name="(styleClass|class)"', r'name="cssClass"', content)
+
+    # Remove tr="true" from any string within a cssClass property, just in case.
+    # This is a bit more complex with regex if notr="true" is also a possibility.
+    # A simpler approach for this specific problem is to ensure the problematic uic behavior isn't triggered.
+    # The key is that setProperty("cssClass", "blue") will not involve QCoreApplication::translate.
+    # So, ensuring the property name is not "class" and not one that uic might specially handle (like styleClass did)
+    # is the primary fix. The python script already changes to cssClass.
+    # For robustness, let's remove tr="true" if it's directly in a string tag of a cssClass property.
+    content = re.sub(r'(<property name="cssClass">\s*<string)([^>]*) tr="true"([^>]*)>', r'\1\2\3>', content, flags=re.DOTALL)
+    # And ensure notr="true" is added if no translation-related attribute is present.
+    # This regex looks for <string> tags directly under cssClass that don't have notr or tr.
+    # content = re.sub(r'(<property name="cssClass">\s*<string)(?![^>]*notr="true")(?![^>]*tr="true")([^>]*)>', r'\1 notr="true"\2>', content, flags=re.DOTALL)
+    # Simpler: The rename to cssClass should be sufficient to avoid uic's special handling that involves QCoreApplication::translate.
+    # The original script's approach of renaming to cssClass is the main fix for the .ui file.
+
+    with open(ui_file, 'w', encoding='utf-8') as f:
+        f.write(content)
+    print(f"{ui_file} patched successfully.")
+else:
+    print(f"ERROR: Could not find {ui_file} to patch.")
+
+# Proactively find and patch the QSS file. It's likely listed in style.qrc.
+qss_file_path = None
+if os.path.exists(style_qrc):
+    with open(style_qrc, 'r', encoding='utf-8') as f:
+        qrc_content = f.read()
+    match = re.search(r'<file>([^<]+\.qss)</file>', qrc_content)
+    if match:
+        qss_file_path = os.path.join(project_dir, match.group(1))
+
+if qss_file_path and os.path.exists(qss_file_path):
+    print(f"Patching stylesheet {qss_file_path} to match UI property change...")
+    with open(qss_file_path, 'r', encoding='utf-8') as f:
+        qss_content = f.read()
+    # Replace styleClass and class selectors with cssClass
+    qss_content = re.sub(r'\[(styleClass|class)=([^\]]+)\]', r'[cssClass=\2]', qss_content)
+    with open(qss_file_path, 'w', encoding='utf-8') as f:
+        f.write(qss_content)
+    print(f"{qss_file_path} patched successfully.")
+else:
+    print("Warning: Stylesheet (.qss) not found or specified in style.qrc. Manual review may be needed if styling breaks.")
+
+# --- Part 2: Apply the correct C++ fixes ---
+print(f"Patching {fi_cpp} for removed 'spinBox_retry'...")
+if os.path.exists(fi_cpp):
+    with open(fi_cpp, 'r', encoding='utf-8') as f:
+        content = f.read()
+    # Replace the call to the missing widget with a sensible default value of 1.
+    content = re.sub(r'ui->spinBox_retry->value\(\)', '1', content)
+    with open(fi_cpp, 'w', encoding='utf-8') as f:
+        f.write(content)
+    print(f"{fi_cpp} patched successfully.")
+
+print(f"Patching {mw_cpp} to comment out obsolete language/update functions...")
+if os.path.exists(mw_cpp):
+     with open(mw_cpp, 'r', encoding='utf-8') as f:
+        content = f.read()
+     # Comment out references to the deleted widgets.
+     content = re.sub(r'^(.*ui->comboBox_language.*)$', r'// \1', content, flags=re.MULTILINE)
+     content = re.sub(r'^(.*ui->comboBox_UpdateChannel.*)$', r'// \1', content, flags=re.MULTILINE)
+     with open(mw_cpp, 'w', encoding='utf-8') as f:
+        f.write(content)
+     print(f"{mw_cpp} patched successfully.")
+
+# --- Part 3: Update Copyright Notices ---
+print("Applying copyright and style guide updates...")
+copyright_notice = """/*
+Copyright (C) 2025  beyawnko
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    My Github homepage: https://github.com/beyawnko
+*/"""
+
+files_to_update = [fi_cpp, mw_cpp] # Add other cpp files if needed
+# List all cpp files in Waifu2x-Extension-QT, excluding specific ones if necessary
+all_cpp_files_in_project = []
+for root, dirs, files in os.walk(project_dir):
+    for file in files:
+        if file.endswith(".cpp"):
+            all_cpp_files_in_project.append(os.path.join(root, file))
+# Add specific files from other directories if they exist and need update
+# Example: launcher_main_cpp = os.path.join('Waifu2x-Extension-QT-Launcher', 'main.cpp')
+# if os.path.exists(launcher_main_cpp):
+#    all_cpp_files_in_project.append(launcher_main_cpp)
+
+# Filter out files that might not need this generic update or are problematic
+# For now, let's assume all .cpp files in Waifu2x-Extension-QT should be updated
+# files_to_update = all_cpp_files_in_project
+
+# The user script specified only fi_cpp and mw_cpp for copyright update. Let's stick to that for now.
+# If a broader update is needed, files_to_update should be populated differently.
+
+for file_path in files_to_update: # Using the original files_to_update list from user script
+    if os.path.exists(file_path):
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Remove old copyright notice (make it more general)
+        # This regex tries to find typical C-style block comments at the start of the file
+        # that look like copyright notices.
+        content = re.sub(r'^\s*/\*.*Copyright.*?My Github homepage:.*?\*/\s*', '', content, flags=re.DOTALL | re.MULTILINE)
+        content = content.strip() # Remove leading/trailing whitespace after stripping old copyright
+
+        # Add new copyright notice
+        new_content = f"{copyright_notice}\n\n{content}"
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        print(f"Updated copyright for {file_path}")
+    else:
+        print(f"Warning: Copyright update skipped, {file_path} not found.")
+
+print("\n--- Definitive fixes applied. The build should now succeed. ---")


### PR DESCRIPTION
This commit attempts to resolve build failures primarily stemming from Qt's User Interface Compiler (uic) generating incorrect C++ code for custom styling properties in `mainwindow.ui`. Additionally, it addresses C++ errors caused by references to UI elements that were removed or renamed.

Summary of actions taken:

1.  **Initial Environment Setup & Dependency Resolution (Linux):**
    *   Switched from Windows build script to `linux_build_script.sh`.
    *   Installed missing dependencies: `pyside6`, `qt6-base-dev`, `qt6-tools-dev`, `qt6-l10n-tools`, `qmake6`, `qt6-multimedia-dev`, `qt6-5compat-dev`, `qt6-shadertools-dev`.

2.  **Addressing C++ Errors for Obsolete UI Elements:**
    *   Identified that `spinBox_retry`, `frame_FrameInterpolation`, `comboBox_language`, and `comboBox_UpdateChannel` were removed/renamed in `mainwindow.ui` but still referenced in C++ code.
    *   Patched relevant C++ files (`Frame_Interpolation.cpp`, `checkupdate.cpp`, `mainwindow.cpp`, `settings.cpp`, `textBrowser.cpp`) to handle the absence of these UI elements, typically by defaulting logic or commenting out problematic lines. For example, `spinBox_retry->value()` was replaced with the literal `1`.

3.  **Addressing `setClass` / `setCssClass` Build Errors from `uic`:**
    *   The primary build error was `‘class QPushButton’ has no member named ‘setClass’` (or `setCssClass` after some attempts). This occurs when `uic` processes properties like `<property name="class">` (or `cssClass`, `styleClass`) in `mainwindow.ui` and generates direct setter calls (e.g., `button->setClass(...)`) instead of `button->setProperty(...)`, especially if the string value was marked as translatable (`tr="true"`).

    *   **Attempts to fix `mainwindow.ui` directly:**
        *   Tried renaming the property from `class` to `styleClass` or `cssClass`.
        *   Attempted to remove `tr="true"` attributes from string values of these properties.
        *   These direct modifications to `mainwindow.ui` using `replace_with_git_merge_diff` proved unreliable and difficult for global changes in the large XML file, often leading to misapplied patches or the tool failing to find all instances.

    *   **Current (Partial) Approach: Patching `ui_mainwindow.h`:**
        *   The strategy shifted to modifying the `uic`-generated `ui_mainwindow.h` file *after* it's created during the build.
        *   The goal was to replace calls like `pushButton_XYZ->setClass(QCoreApplication::translate(...));` with `pushButton_XYZ->setProperty("cssClass", QStringLiteral("..."));`.
        *   This patching was performed for 11 buttons (PayPal, Patreon, Start, Stop, ForceRetry, HideSettings, HideTextBro, CustRes_apply, CustRes_cancel, DetectGPU, ShowMultiGPUSettings_Waifu2xNCNNVulkan).

4.  **Outstanding Issues / Stuck Point:**
    *   The manual patching of `ui_mainwindow.h` is incomplete (approximately 19 more buttons needed patching based on the initial error log). This piecemeal approach is very time-consuming and not ideal.
    *   The root cause in `mainwindow.ui` (how `uic` handles properties named `class`, `styleClass`, or `cssClass`, especially with potentially translatable string values) has not been definitively fixed in a global and reliable way due to tool limitations for XML manipulation.
    *   The C++ code that *uses* these properties for styling (likely in `UiController.cpp` and QSS files) has not yet been updated to reflect the change to `setProperty("cssClass", ...)`. This would be the next step after successfully patching `ui_mainwindow.h` and getting the C++ object files to compile.

Due to the iterative and error-prone nature of patching `ui_mainwindow.h` with the current tools, and the inability to perform a robust global modification of `mainwindow.ui`, the build is still likely to fail in its current state. The submitted code reflects the C++ fixes for obsolete UI elements and the partial patching of `ui_mainwindow.h`.