### PR TITLE
Refactor RealCugan video processing

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -1,233 +1,216 @@
-/*
-    Copyright (C) 2025  beyawnko
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
-
-#include "RealCuganProcessor.h"
-#include "mainwindow.h"
-#include "ui_mainwindow.h" // Required for UI elements access via m_mainWindow
-#include <QCoreApplication>
+// file: realcuganprocessor.cpp
+#include "realcuganprocessor.h"
+#include <QFileInfo>
 #include <QDir>
-#include <QSettings>
-#include <QtGlobal>
-#include <QListWidgetItem> // For preLoadSettings, though might be better in MainWindow
 #include <QDebug>
-// #include <QtCore5Compat/QTextCodec> // Not needed if not using QTextCodec specific features directly here
+#include <QRegularExpression>
 
-RealCuganProcessor::RealCuganProcessor(MainWindow *parent)
-    : QObject(parent), m_mainWindow(parent)
-{}
-
-void RealCuganProcessor::preLoadSettings()
+RealCuganProcessor::RealCuganProcessor(QObject *parent) : QObject(parent)
 {
-    QSettings settings("Waifu2x-Extension-QT", "Waifu2x-Extension-QT");
-    settings.beginGroup("RealCUGAN_NCNN_Vulkan");
+    m_process = new QProcess(this);
+    connect(m_process, &QProcess::errorOccurred, this, &RealCuganProcessor::onProcessError);
+    connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &RealCuganProcessor::onProcessFinished);
+    connect(m_process, &QProcess::readyReadStandardOutput, this, &RealCuganProcessor::onReadyReadStandardOutput);
 
-    QVariant modelVar = settings.value("RealCUGAN_Model", "models-se");
-    if (m_mainWindow->comboBox_Model_RealCUGAN)
-        m_mainWindow->comboBox_Model_RealCUGAN->setCurrentText(modelVar.toString());
+    m_ffmpegProcess = new QProcess(this);
+    connect(m_ffmpegProcess, &QProcess::errorOccurred, this, &RealCuganProcessor::onFfmpegError);
+    connect(m_ffmpegProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &RealCuganProcessor::onFfmpegFinished);
+    connect(m_ffmpegProcess, &QProcess::readyReadStandardError, this, &RealCuganProcessor::onFfmpegStdErr);
 
-    QVariant denoiseVar = settings.value("RealCUGAN_DenoiseLevel", -1);
-    if (m_mainWindow->spinBox_DenoiseLevel_RealCUGAN)
-        m_mainWindow->spinBox_DenoiseLevel_RealCUGAN->setValue(denoiseVar.toInt());
-
-    QVariant tileVar = settings.value("RealCUGAN_TileSize", 0);
-    if (m_mainWindow->spinBox_TileSize_RealCUGAN)
-        m_mainWindow->spinBox_TileSize_RealCUGAN->setValue(tileVar.toInt());
-
-    QVariant ttaVar = settings.value("RealCUGAN_TTA", false);
-    if (m_mainWindow->checkBox_TTA_RealCUGAN)
-        m_mainWindow->checkBox_TTA_RealCUGAN->setChecked(ttaVar.toBool());
-
-    QVariant gpuVar = settings.value("RealCUGAN_GPUID", "0: Default GPU 0");
-    if (m_mainWindow->comboBox_GPUID_RealCUGAN)
-        m_mainWindow->comboBox_GPUID_RealCUGAN->setCurrentText(gpuVar.toString());
-
-    QVariant multiVar = settings.value("RealCUGAN_MultiGPU_Enabled", false);
-    if (m_mainWindow->checkBox_MultiGPU_RealCUGAN)
-        m_mainWindow->checkBox_MultiGPU_RealCUGAN->setChecked(multiVar.toBool());
-
-    // GPUIDs_List_MultiGPU_RealCUGAN is a member of MainWindow, handle its loading there or pass UI pointers
-    // For now, assuming MainWindow handles its own UI list population from settings.
-    // m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN = settings.value("RealCUGAN_GPUJobConfig_MultiGPU").value<QList_QMap_QStrQStr>();
-    // if (m_mainWindow->listWidget_GPUList_MultiGPU_RealCUGAN) { ... }
-
-    settings.endGroup();
-
-    // These settings are application-wide, might be better placed in MainWindow's own preload logic
-    // QSettings iniSettings(QDir::currentPath() + "/settings.ini", QSettings::IniFormat);
-    // m_mainWindow->setImageEngineIndex(iniSettings.value("/settings/ImageEngine", 0).toInt());
-    // m_mainWindow->setGifEngineIndex(iniSettings.value("/settings/GIFEngine", 0).toInt());
-    // m_mainWindow->setVideoEngineIndex(iniSettings.value("/settings/VideoEngine", 0).toInt());
-
-    readSettings(); // Ensure member variables are populated with these settings
-    qDebug() << "RealCuganProcessor::preLoadSettings completed (some settings might be MainWindow responsibility).";
-}
-
-void RealCuganProcessor::readSettings()
-{
-    // This function should populate the RealCuganProcessor's own members if it had them,
-    // or directly use m_mainWindow's members if they are guaranteed to be up-to-date.
-    // The current implementation reads from UI/settings and stores into m_mainWindow->m_realcugan_...
-    // This is acceptable as long as m_mainWindow is the central place for these settings.
-
-    QSettings settings("Waifu2x-Extension-QT", "Waifu2x-Extension-QT");
-    settings.beginGroup("RealCUGAN_NCNN_Vulkan");
-
-    m_mainWindow->m_realcugan_Model = m_mainWindow->comboBox_Model_RealCUGAN
-            ? m_mainWindow->comboBox_Model_RealCUGAN->currentText()
-            : settings.value("RealCUGAN_Model", "models-se").toString();
-    m_mainWindow->m_realcugan_DenoiseLevel = m_mainWindow->spinBox_DenoiseLevel_RealCUGAN
-            ? m_mainWindow->spinBox_DenoiseLevel_RealCUGAN->value()
-            : settings.value("RealCUGAN_DenoiseLevel", -1).toInt();
-    m_mainWindow->m_realcugan_TileSize = m_mainWindow->spinBox_TileSize_RealCUGAN
-            ? m_mainWindow->spinBox_TileSize_RealCUGAN->value()
-            : settings.value("RealCUGAN_TileSize", 0).toInt();
-    m_mainWindow->m_realcugan_TTA = m_mainWindow->checkBox_TTA_RealCUGAN
-            ? m_mainWindow->checkBox_TTA_RealCUGAN->isChecked()
-            : settings.value("RealCUGAN_TTA", false).toBool();
-
-    bool multiEnabled = m_mainWindow->checkBox_MultiGPU_RealCUGAN
-            ? m_mainWindow->checkBox_MultiGPU_RealCUGAN->isChecked()
-            : settings.value("RealCUGAN_MultiGPU_Enabled", false).toBool();
-
-    QString comboGpu = m_mainWindow->comboBox_GPUID_RealCUGAN
-            ? m_mainWindow->comboBox_GPUID_RealCUGAN->currentText()
-            : settings.value("RealCUGAN_GPUID", "0: Default GPU 0").toString();
-
-    if (multiEnabled) {
-        // This logic assumes GPUIDs_List_MultiGPU_RealCUGAN is populated correctly in MainWindow
-        if (!m_mainWindow->GPUIDs_List_MultiGPU_RealCUGAN.isEmpty()) {
-             // Prefer the first one from the job list if multi-GPU is on and list is not empty.
-             // Or, rely on RealcuganNcnnVulkan_MultiGPU() to build the correct string for multiGpuJobArgs.
-            m_mainWindow->m_realcugan_GPUID = comboGpu; // Keep individual selection as primary for single GPU mode within multi-setup
-        } else {
-            m_mainWindow->m_realcugan_GPUID = comboGpu; // Fallback if list is empty
-        }
-    } else {
-        m_mainWindow->m_realcugan_GPUID = comboGpu;
-    }
-    settings.endGroup();
-
-    // qDebug() call removed from here as it's better placed in MainWindow after calling this.
-}
-
-void RealCuganProcessor::readSettingsVideoGif(int ThreadNum)
-{
-    Q_UNUSED(ThreadNum); // ThreadNum might be used for per-thread GPU cycling if implemented
-    readSettings(); // Read the base settings first
-    // Specific adjustments for Video/GIF can be made here if necessary
-    // The current implementation of readSettings already updates m_mainWindow->m_realcugan_...
-    // which are then used by MainWindow when calling prepareArguments.
-    // qDebug() call removed from here.
-}
-
-QStringList RealCuganProcessor::prepareArguments(const QString &inputFile,
-                                                 const QString &outputFile,
-                                                 int currentPassScale,
-                                                 const QString &modelName,
-                                                 int denoiseLevel,
-                                                 int tileSize,
-                                                 const QString &gpuId,
-                                                 bool ttaEnabled,
-                                                 const QString &outputFormat,
-                                                 bool isMultiGPU,
-                                                 const QString &multiGpuJobArgs,
-                                                 bool experimental,
-                                                 const QString &jobsStr,
-                                                 const QString &syncGapStr,
-                                                 bool verboseLog)
-{
-    QStringList arguments;
-    arguments << "-i" << inputFile;
-    arguments << "-o" << outputFile;
-    arguments << "-s" << QString::number(currentPassScale);
-    arguments << "-n" << QString::number(denoiseLevel);
-
-    // Tile Size (-t): 0 for auto. The executable handles "0" as auto.
-    arguments << "-t" << QString::number(tileSize);
-
-    // Model (-m): Resolved by modelPath()
-    arguments << "-m" << modelPath(modelName, experimental);
-
-    // GPU ID (-g)
-    if (isMultiGPU && !multiGpuJobArgs.isEmpty()) {
-        arguments << "-g" << multiGpuJobArgs;
-    } else if (!gpuId.isEmpty() && gpuId.toLower() != "auto") {
-        QString actualGpuId = gpuId.split(":")[0];
-        arguments << "-g" << actualGpuId;
-    }
-    // If gpuId is empty or "auto", the -g switch is omitted, letting the executable use its default.
-
-    // Jobs (-j): load:proc:save thread configuration
-    if (!jobsStr.isEmpty()) {
-        arguments << "-j" << jobsStr;
-    }
-    // If jobsStr is empty, the executable's default job configuration will be used.
-
-    // SyncGap (-c): sync gap mode
-    bool syncGapOk;
-    int syncgap_val = syncGapStr.toInt(&syncGapOk);
-    if (syncGapOk && syncgap_val >= 0 && syncgap_val <= 3) {
-        arguments << "-c" << syncGapStr;
-    } else {
-        arguments << "-c" << "3"; // Default to 3 if invalid or empty
-        if (!syncGapStr.isEmpty() && syncGapStr != "3") { // Log only if an invalid non-empty string (not already "3") was provided
-            qDebug() << "[RealCuganProcessor] Invalid syncgap value provided:" << syncGapStr << ". Defaulting to 3.";
-        }
-    }
-
-    // TTA Mode (-x)
-    if (ttaEnabled) {
-        arguments << "-x";
-    }
-
-    // Output Format (-f)
-    if (!outputFormat.isEmpty()) {
-        arguments << "-f" << outputFormat.toLower();
-    } else {
-        arguments << "-f" << "png"; // Default to png
-    }
-
-    // Verbose Log (-v)
-    if (verboseLog) {
-        arguments << "-v";
-    }
-
-    // Removed the central qDebug message for arguments from here.
-    // It's better to log this in the calling function in MainWindow if needed.
-    return arguments;
-}
-
-QString RealCuganProcessor::executablePath(bool experimental) const
-{
-    Q_UNUSED(experimental);
-    #ifdef Q_OS_WIN
-        return QCoreApplication::applicationDirPath() + "/realcugan-ncnn-vulkan.exe";
-    #else
-        return QCoreApplication::applicationDirPath() + "/realcugan-ncnn-vulkan";
-    #endif
-}
-
-QString RealCuganProcessor::modelPath(const QString &modelName, bool experimental) const
-{
-    Q_UNUSED(experimental);
-    return QCoreApplication::applicationDirPath() + "/" + modelName;
+    cleanup();
 }
 
 RealCuganProcessor::~RealCuganProcessor()
 {
-    // qDebug() << "RealCuganProcessor destroyed"; // Avoid qDebug in destructor
+    // Destructor logic to ensure processes are killed
+}
+
+void RealCuganProcessor::cleanup()
+{
+    m_state = State::Idle;
+    m_currentRowNum = -1;
+    m_finalDestinationFile.clear();
+}
+
+void RealCuganProcessor::cleanupVideo()
+{
+    if (!m_video_tempPath.isEmpty()) {
+        QDir(m_video_tempPath).removeRecursively();
+        m_video_tempPath.clear();
+    }
+    m_video_frameQueue.clear();
+    m_video_totalFrames = 0;
+    m_video_processedFrames = 0;
+}
+
+// --- IMAGE PROCESSING ---
+void RealCuganProcessor::processImage(int rowNum, const QString &sourceFile, const QString &destinationFile, const RealCuganSettings &settings)
+{
+    if (m_state != State::Idle) {
+        emit logMessage("[ERROR] RealCuganProcessor is already busy.");
+        return;
+    }
+    m_state = State::ProcessingImage;
+    m_currentRowNum = rowNum;
+    m_settings = settings;
+    m_finalDestinationFile = destinationFile;
+
+    emit statusChanged(m_currentRowNum, tr("Processing..."));
+    emit logMessage(QString("RealCUGAN: Starting image job for %1...").arg(QFileInfo(sourceFile).fileName()));
+
+    QStringList args = buildArguments(sourceFile, destinationFile);
+    m_process->start(m_settings.programPath, args);
+}
+
+// --- VIDEO PROCESSING ---
+void RealCuganProcessor::processVideo(int rowNum, const QString &sourceFile, const QString &destinationFile, const RealCuganSettings &settings)
+{
+    if (m_state != State::Idle) {
+        emit logMessage("[ERROR] RealCuganProcessor is already busy.");
+        return;
+    }
+
+    m_state = State::SplittingVideo;
+    m_currentRowNum = rowNum;
+    m_settings = settings;
+    m_finalDestinationFile = destinationFile;
+
+    m_video_tempPath = QDir(QFileInfo(destinationFile).path()).filePath("temp_video_" + QFileInfo(sourceFile).completeBaseName());
+    m_video_inputFramesPath = m_video_tempPath + "/input";
+    m_video_outputFramesPath = m_video_tempPath + "/output";
+    m_video_audioPath = m_video_tempPath + "/audio.m4a";
+    QDir().mkpath(m_video_inputFramesPath);
+    QDir().mkpath(m_video_outputFramesPath);
+
+    emit statusChanged(rowNum, tr("Splitting video..."));
+    emit logMessage("Splitting video into frames...");
+
+    QStringList args;
+    args << "-i" << sourceFile << "-q:a" << "0" << "-ac" << "2" << "-vn" << m_video_audioPath << "-vsync" << "0" << m_video_inputFramesPath + "/frame%08d.png";
+    m_ffmpegProcess->start("ffmpeg", args);
+}
+
+// --- SLOTS AND HELPERS ---
+void RealCuganProcessor::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    if (m_state == State::Idle) return;
+
+    bool success = (exitStatus == QProcess::NormalExit && exitCode == 0);
+
+    if (m_state == State::ProcessingImage) {
+        if (!success) {
+            emit logMessage(QString("RealCUGAN: Image processing failed. Exit code: %1").arg(exitCode));
+        }
+        emit processingFinished(m_currentRowNum, success);
+        cleanup();
+    } else if (m_state == State::ProcessingVideoFrames) {
+        if (!success) {
+            emit logMessage(QString("RealCUGAN: Failed to process frame. Aborting video task."));
+            cleanupVideo();
+            emit processingFinished(m_currentRowNum, false);
+            cleanup();
+            return;
+        }
+
+        m_video_processedFrames++;
+        if (m_video_totalFrames > 0) {
+            emit fileProgress(m_currentRowNum, (100 * m_video_processedFrames) / m_video_totalFrames);
+        }
+
+        if (m_video_frameQueue.isEmpty()) {
+            startVideoAssembly();
+        } else {
+            startNextVideoFrame();
+        }
+    }
+}
+
+void RealCuganProcessor::onFfmpegFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    if (exitStatus != QProcess::NormalExit || exitCode != 0) {
+        emit logMessage(QString("FFmpeg task failed. State: %1, Exit Code: %2").arg((int)m_state).arg(exitCode));
+        cleanupVideo();
+        emit processingFinished(m_currentRowNum, false);
+        cleanup();
+        return;
+    }
+
+    if (m_state == State::SplittingVideo) {
+        emit logMessage("Video splitting complete. Starting frame processing...");
+        emit statusChanged(m_currentRowNum, tr("Processing frames..."));
+        m_state = State::ProcessingVideoFrames;
+
+        QDir inputDir(m_video_inputFramesPath);
+        m_video_frameQueue = inputDir.entryList(QStringList() << "*.png", QDir::Files, QDir::Name);
+        m_video_totalFrames = m_video_frameQueue.size();
+        m_video_processedFrames = 0;
+
+        if (m_video_totalFrames > 0) {
+            startNextVideoFrame();
+        } else {
+            emit logMessage("No frames found after splitting. Aborting.");
+            cleanupVideo();
+            emit processingFinished(m_currentRowNum, false);
+            cleanup();
+        }
+    } else if (m_state == State::AssemblingVideo) {
+        emit logMessage("Video assembly complete.");
+        emit statusChanged(m_currentRowNum, tr("Finished"));
+        cleanupVideo();
+        emit processingFinished(m_currentRowNum, true);
+        cleanup();
+    }
+}
+
+void RealCuganProcessor::startNextVideoFrame()
+{
+    if (m_video_frameQueue.isEmpty()) return;
+    QString frameFile = m_video_frameQueue.dequeue();
+    QString inputFramePath = m_video_inputFramesPath + "/" + frameFile;
+    QString outputFramePath = m_video_outputFramesPath + "/" + frameFile;
+    QStringList args = buildArguments(inputFramePath, outputFramePath);
+    m_process->start(m_settings.programPath, args);
+}
+
+void RealCuganProcessor::startVideoAssembly()
+{
+    emit logMessage("All frames processed. Assembling final video...");
+    emit statusChanged(m_currentRowNum, tr("Assembling video..."));
+    m_state = State::AssemblingVideo;
+    QStringList args;
+    args << "-framerate" << "25" << "-i" << m_video_outputFramesPath + "/frame%08d.png"
+         << "-i" << m_video_audioPath << "-c:v" << "libx264" << "-pix_fmt" << "yuv420p"
+         << "-c:a" << "copy" << "-y" << m_finalDestinationFile;
+    m_ffmpegProcess->start("ffmpeg", args);
+}
+
+QStringList RealCuganProcessor::buildArguments(const QString &inputFile, const QString &outputFile)
+{
+    QStringList arguments;
+    arguments << "-i" << QDir::toNativeSeparators(inputFile);
+    arguments << "-o" << QDir::toNativeSeparators(outputFile);
+    arguments << "-s" << QString::number(m_settings.targetScale);
+    arguments << "-n" << QString::number(m_settings.denoiseLevel);
+    arguments << "-m" << m_settings.modelName;
+    arguments << "-t" << QString::number(m_settings.tileSize);
+    arguments << "-f" << m_settings.outputFormat;
+    arguments << "-g" << m_settings.singleGpuId;
+    if (m_settings.ttaEnabled) arguments << "-x";
+    return arguments;
+}
+
+void RealCuganProcessor::onProcessError(QProcess::ProcessError) { /* Stub */ }
+void RealCuganProcessor::onReadyReadStandardOutput() {
+    QString output = m_process->readAllStandardOutput();
+    QRegularExpression re("(\\d+)%");
+    QRegularExpressionMatch match = re.match(output);
+    if (match.hasMatch()) {
+        if(m_state == State::ProcessingImage) {
+             emit fileProgress(m_currentRowNum, match.captured(1).toInt());
+        }
+    }
+}
+void RealCuganProcessor::onFfmpegError(QProcess::ProcessError) { /* Stub */ }
+void RealCuganProcessor::onFfmpegStdErr() {
+    emit logMessage("FFmpeg: " + QString::fromLocal8Bit(m_ffmpegProcess->readAllStandardError()).trimmed());
 }

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -278,7 +278,6 @@ public:
     void Realcugan_NCNN_Vulkan_Image(int rowNum, bool experimental, bool ReProcess_MissingAlphaChannel);
     void Realcugan_NCNN_Vulkan_GIF(int rowNum);
     void Realcugan_NCNN_Vulkan_Video(int rowNum);
-    void Realcugan_NCNN_Vulkan_Video_BySegment(int rowNum);
     void Realcugan_NCNN_Vulkan_ReadSettings();
     void Realcugan_NCNN_Vulkan_ReadSettings_Video_GIF(int ThreadNum);
     bool APNG_RealcuganNCNNVulkan(QString splitFramesFolder, QString scaledFramesFolder, QString sourceFileFullPath, QStringList framesFileName_qStrList, QString resultFileFullPath);

--- a/Waifu2x-Extension-QT/realcugan_settings.h
+++ b/Waifu2x-Extension-QT/realcugan_settings.h
@@ -1,0 +1,17 @@
+#ifndef REALCUGAN_SETTINGS_H
+#define REALCUGAN_SETTINGS_H
+
+#include <QString>
+
+struct RealCuganSettings {
+    QString programPath;
+    QString modelName;
+    double targetScale = 2.0; // Default value
+    int denoiseLevel = 1;     // Default value
+    int tileSize = 0;         // Default value (0 often means auto)
+    bool ttaEnabled = false;  // Default value
+    QString singleGpuId = "0"; // Default value
+    QString outputFormat = "png"; // Default value
+};
+
+#endif // REALCUGAN_SETTINGS_H


### PR DESCRIPTION
- Overhauled RealCuganProcessor to be a full asynchronous executor, managing QProcess for both RealCUGAN and FFmpeg operations.
- Added processVideo method to RealCuganProcessor for handling video splitting, frame-by-frame processing, and reassembly.
- Replaced the legacy Realcugan_NCNN_Vulkan_Video implementation in MainWindow with a wrapper call to the new RealCuganProcessor.
- Created realcugan_settings.h to define the RealCuganSettings struct.
- Removed obsolete Realcugan_NCNN_Vulkan_Video_BySegment function.