### PR TITLE
Fix: Overhaul Home tab UI and address compilation errors

### DIFF
--- a/Waifu2x-Extension-QT/UiController.cpp
+++ b/Waifu2x-Extension-QT/UiController.cpp
@@ -66,9 +66,12 @@ void UiController::applyDarkStyle(int mode)
 
 void UiController::outputSettingsAreaSetEnabled(Ui::MainWindow *ui, bool enabled)
 {
-    ui->scrollArea_outputPathSettings->setEnabled(enabled);
-    ui->lineEdit_outputPath->setClearButtonEnabled(enabled);
-    ui->lineEdit_outputPath->setFocusPolicy(enabled ? Qt::StrongFocus : Qt::NoFocus);
+    // Original code used ui->scrollArea_outputPathSettings->setEnabled(enabled);
+    // Replacing with groupBox_OutPut as it's the current container for these settings.
+    // Child widgets like lineEdit_outputPath will inherit the enabled state.
+    ui->groupBox_OutPut->setEnabled(enabled);
+    ui->lineEdit_outputPath->setClearButtonEnabled(enabled); // Keep this line as it's specific to the line edit
+    ui->lineEdit_outputPath->setFocusPolicy(enabled ? Qt::StrongFocus : Qt::NoFocus); // Keep this line
 }
 
 void UiController::updateEngineSettingsVisibility(Ui::MainWindow *ui, const QString& selectedEngineName)

--- a/Waifu2x-Extension-QT/mainwindow.ui
+++ b/Waifu2x-Extension-QT/mainwindow.ui
@@ -8246,6 +8246,13 @@ padding:10px;
              </property>
             </widget>
            </item>
+                   <item>
+                    <widget class="QCheckBox" name="checkBox_OutPath_KeepOriginalFileName">
+                     <property name="text">
+                      <string>Keep original file name</string>
+                     </property>
+                    </widget>
+                   </item>
           </layout>
          </item>
         </layout>


### PR DESCRIPTION
This commit primarily overhauls the Home tab UI layout in `Waifu2x-Extension-QT/mainwindow.ui` for stability and clarity, resolving issues with overlapping panels, misplaced controls, and resizing problems.

It also includes fixes for compilation errors that arose after the initial UI modification:
- Added `checkBox_OutPath_KeepOriginalFileName` back to the output settings group in the UI.
- Modified `UiController.cpp` to correctly reference `groupBox_OutPut` for enabling/disabling output path settings, instead of the removed `scrollArea_outputPathSettings`.

Note: Build issues persist with the `realesrgan-ncnn-vulkan` component due to submodule problems. This engine may not be functional in this commit.