### PR TITLE
Fix: Update QtConcurrent::run syntax for ExecuteCompatibilityTests

### DIFF
--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -760,7 +760,7 @@ void MainWindow::StartFullCompatibilityTest()
         return;
     }
     ui->pushButton_compatibilityTest->setEnabled(false);
-    compatibilityTestFuture = QtConcurrent::run(this, &MainWindow::ExecuteCompatibilityTests);
+    compatibilityTestFuture = QtConcurrent::run([this] { this->ExecuteCompatibilityTests(); });
 }
 
 void MainWindow::ExecuteCompatibilityTests()


### PR DESCRIPTION
Changed the QtConcurrent::run call for ExecuteCompatibilityTests to use modern C++ lambda syntax to resolve template instantiation errors with MinGW and Qt 6.

Replaces `QtConcurrent::run(this, &MainWindow::ExecuteCompatibilityTests)` with `QtConcurrent::run([this] { this->ExecuteCompatibilityTests(); })`.