### PR TITLE
Fix table init on new settings

### DIFF
--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -40,6 +40,8 @@ int MainWindow::Settings_Read_Apply()
         QAction_checkBox_MoveToRecycleBin_checkBox_DelOriginal->setChecked(1);// 
 //         if(isBetaVer)comboBox_UpdateChannel_setCurrentIndex_self(1);
         Settings_Save();
+        Init_Table();
+        Table_FileCount_reload();
 //         Settings_Read_Apply();
         return 0;
     }


### PR DESCRIPTION
## Summary
- call `Init_Table` and `Table_FileCount_reload` when settings.ini is missing so table models initialize properly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3a7e2f188322a3fc9ba7894fed91