### PR TITLE
Remove Qt5Compat usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qtbase5-dev qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-5compat-dev qt6-shadertools-dev libegl1 cppcheck qt6-declarative-dev qt6-tools-dev
+          sudo apt-get install -y qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev libegl1 cppcheck qt6-declarative-dev qt6-tools-dev
           pip install -r requirements.txt
       - name: Static analysis
         run: |
@@ -34,7 +34,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: '6.5.2'
-          modules: 'qtmultimedia qtshadertools qt5compat'
+          modules: 'qtmultimedia qtshadertools'
       - name: Install build tools
         run: |
           choco install make cmake -y

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RealCUGAN and RealESRGAN are currently the only supported upscaling engines.
 
 ## Dependencies
 
-- **Qt5compat/Qt 6** development environment (Core, GUI, Widgets, Multimedia, OpenGL, OpenGLWidgets, Qt5Compat modules)
+ - **Qt 6** development environment (Core, GUI, Widgets, Multimedia, OpenGL, OpenGLWidgets modules)
 - **C++17** compatible compiler (I am currently in the process of working on experimental refactoring to C++20 for
   coroutines)
 - **FFmpeg** for handling video input/output
@@ -34,7 +34,7 @@ menus. Detected IDs are saved to `settings.ini` so that subsequent launches rest
 
 ### Quick Build (Linux & Windows)
 
-1. Install **Qt 6.5** with the Widgets, Multimedia, OpenGL and Qt5Compat modules. A C++17 compiler is required (GCC 7+
+1. Install **Qt 6.5** with the Widgets, Multimedia, and OpenGL modules. A C++17 compiler is required (GCC 7+
    on Linux or the MSYS2 MinGW-w64 toolchain on Windows).
 1. Clone the repository and its submodules:
    ```bash
@@ -134,11 +134,11 @@ git submodule update --init --recursive
 
 1. **Qt Development Libraries**:
 
-   - Qt 6 (e.g., version 6.5.2). You'll need the `core`, `gui`, `widgets`, and `multimedia` components, plus the
-     `opengl`, `openglwidgets`, and `qt5compat` modules.
+  - Qt 6 (e.g., version 6.5.2). You'll need the `core`, `gui`, `widgets`, and `multimedia` components,
+    along with the `opengl` and `openglwidgets` modules.
    - Installation example for Debian/Ubuntu systems:
      ```bash
-     sudo apt install qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-5compat-dev qt6-shadertools-dev
+    sudo apt install qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev
      ```
    - If you are using a specific Qt version manager (like `aqtinstall`), ensure that the chosen Qt version's `bin`
      directory is in your system's `PATH`.
@@ -148,10 +148,9 @@ git submodule update --init --recursive
 For a Qt6 environment (preferred) you can install the following packages on Debian/Ubuntu systems:
 
 ```bash
-sudo apt install qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-5compat-dev qt6-shadertools-dev
+sudo apt install qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev
 ```
-
-These packages supply `qmake6`, `qsb`, and the Multimedia and Qt5Compat modules.
+These packages supply `qmake6`, `qsb`, and the Multimedia modules.
 
 3. **Upscaler Dependencies (Vulkan)**:
    - The upscaler engines (RealCUGAN, RealESRGAN) are based on ncnn and use Vulkan for GPU acceleration.
@@ -188,7 +187,7 @@ These packages supply `qmake6`, `qsb`, and the Multimedia and Qt5Compat modules.
      `bin` directory (e.g., `C:\msys64\mingw64\bin`) are added to your system's `PATH` environment variable, especially
      within the MSYS2 MinGW terminal environment.
    - Include the **qtshadertools** module so the Liquid Glass shader can be built.
-   - Install the `opengl`, `openglwidgets`, and `qt5compat` modules.
+    - Install the `opengl` and `openglwidgets` modules.
 
 1. **Upscaler Dependencies (Vulkan for Windows)**:
 
@@ -441,7 +440,7 @@ distributions install them with:
 ```bash
 sudo apt-get update
 sudo apt-get install qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev \
-    qt6-5compat-dev qt6-shadertools-dev cppcheck pkg-config
+    qt6-shadertools-dev cppcheck pkg-config
 ```
 
 Run cppcheck from the repository root:

--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -145,7 +145,7 @@ void RealCuganProcessor::cleanupQtMediaPlayer()
             m_mediaPlayer->stop();
         }
         // Reset source to release file handles if any are held
-        // m_mediaPlayer->setMedia(QMediaContent()); // setMedia is for Qt5, use setSource(QUrl()) for Qt6
+        // m_mediaPlayer->setMedia(QMediaContent()); // use setSource(QUrl()) with Qt6
         m_mediaPlayer->setSource(QUrl());
     }
     // m_videoSink is a child of m_mediaPlayer or this, and its resources are managed by Qt mostly.

--- a/Waifu2x-Extension-QT/SystemTrayIcon.cpp
+++ b/Waifu2x-Extension-QT/SystemTrayIcon.cpp
@@ -22,7 +22,7 @@
 
 /*
 Implementation of the tray icon follows guidance from the Jianshu article
-"Qt5 application system tray" by XiaoQ_wang:
+"Qt application system tray" by XiaoQ_wang:
 https://www.jianshu.com/p/a000044f1f4a
 
 The tutorial explains how to use QSystemTrayIcon to show the application's

--- a/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
+++ b/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
@@ -4,7 +4,7 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-QT       += core gui concurrent multimedia opengl openglwidgets core5compat
+QT       += core gui concurrent multimedia opengl openglwidgets
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/Waifu2x-Extension-QT/mainwindow.cpp
@@ -50,7 +50,6 @@
 #include <QMovie>
 #include <QMediaPlayer>
 #include <QMediaMetaData>
-#include <QTextCodec>
 #include <QDesktopServices>
 #include <QUrl>
 #include <QStandardItem>

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -50,7 +50,6 @@
 #include <QScreen>
 #include <QCloseEvent>
 #include <QFileDialog>
-#include <QtCore5Compat/QTextCodec>
 #include <cmath>
 #include <QSystemTrayIcon>
 #include <QMenu>

--- a/Waifu2x-Extension-QT/settings.cpp
+++ b/Waifu2x-Extension-QT/settings.cpp
@@ -19,7 +19,6 @@
 #include "ui_mainwindow.h"
 #include "UiController.h"
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-#include <QTextCodec>
 #endif
 
 /*
@@ -48,9 +47,6 @@ int MainWindow::Settings_Read_Apply()
     else
     {
         QSettings *configIniRead_ver = new QSettings(settings_ini, QSettings::IniFormat);
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-        configIniRead_ver->setIniCodec(QTextCodec::codecForName("UTF-8"));
-#endif
         QString Settings_VERSION = configIniRead_ver->value("/settings/VERSION").toString();
         if(Settings_VERSION!=VERSION)
         {
@@ -64,9 +60,6 @@ int MainWindow::Settings_Read_Apply()
     }
     //=================
     // QSettings *configIniRead = new QSettings(settings_ini, QSettings::IniFormat); // Unused variable
-// #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-    // configIniRead->setIniCodec(QTextCodec::codecForName("UTF-8"));
-// #endif
     //=================== Load global font settings =========================
     {
         QVariant tmp = Settings_Read_value("/settings/GlobalFontSize");
@@ -1001,16 +994,10 @@ QVariant MainWindow::Settings_Read_value(const QString &Key,
     QString settings_ini_old = Current_Path + "/settings_old.ini";
     QString settings_ini_new = Current_Path + "/settings.ini";
     QSettings configIniRead_new(settings_ini_new, QSettings::IniFormat);
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-    configIniRead_new.setIniCodec(QTextCodec::codecForName("UTF-8"));
-#endif
     //====
     if (isReadOldSettings && QFile::exists(settings_ini_old))
     {
         QSettings configIniRead_old(settings_ini_old, QSettings::IniFormat);
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-        configIniRead_old.setIniCodec(QTextCodec::codecForName("UTF-8"));
-#endif
         //====
         if (configIniRead_old.contains(Key))
         {

--- a/Waifu2x-Extension-QT/topsupporterslist.cpp
+++ b/Waifu2x-Extension-QT/topsupporterslist.cpp
@@ -19,9 +19,6 @@
 
 #include "topsupporterslist.h"
 #include "ui_topsupporterslist.h"
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-#include <QTextCodec>
-#endif
 
 TopSupportersList::TopSupportersList(QWidget *parent) :
     QWidget(parent),
@@ -39,9 +36,6 @@ TopSupportersList::TopSupportersList(QWidget *parent) :
     if(QFile::exists(TopSupportersList_ini_path) == true)
     {
         QSettings *configIniRead = new QSettings(TopSupportersList_ini_path, QSettings::IniFormat);
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-        configIniRead->setIniCodec(QTextCodec::codecForName("UTF-8"));
-#endif
         QString Change_log = configIniRead->value("/TopSupportersList/List").toString();
         if(configIniRead->value("/TopSupportersList/List") != QVariant() && Change_log.trimmed()!="")
         {

--- a/Waifu2x-Extension-QT/video.cpp
+++ b/Waifu2x-Extension-QT/video.cpp
@@ -18,9 +18,6 @@
 */
 #include <QtCore/qglobal.h>
 
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-#include <QTextCodec>
-#endif
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "VideoProcessor.h"

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -214,7 +214,7 @@ function Ensure-QMake {
     }
     $QtDir = (Resolve-Path $QtDir).Path
 
-    $qtModules = @('qtmultimedia', 'qtshadertools', 'qt5compat')
+    $qtModules = @('qtmultimedia', 'qtshadertools')
     $qtInstallArgs = @(
         '-m', 'aqt',
         'install-qt', 'windows', 'desktop', $QtVersion, 'win64_mingw',

--- a/memory/archival/2025-06-24T183813Z-drop-qt5compat.md
+++ b/memory/archival/2025-06-24T183813Z-drop-qt5compat.md
@@ -1,0 +1,4 @@
+## Drop Qt5Compat support
+
+### Summary
+Removed all references to `Qt5Compat` and `QTextCodec` in the main application. Updated build scripts, CI workflow, and documentation to rely solely on Qt6 modules. Adjusted run_cppcheck script to assume Qt6Core. All unit tests pass.

--- a/tools/run_cppcheck.sh
+++ b/tools/run_cppcheck.sh
@@ -6,13 +6,9 @@ if ! command -v pkg-config >/dev/null; then
     exit 1
 fi
 
-QT_PKG=""
-if pkg-config --exists Qt5Core; then
-    QT_PKG=Qt5Core
-elif pkg-config --exists Qt6Core; then
-    QT_PKG=Qt6Core
-else
-    echo "Error: Qt development packages not found. Install qtbase5-dev or qtbase6-dev." >&2
+QT_PKG="Qt6Core"
+if ! pkg-config --exists "$QT_PKG"; then
+    echo "Error: Qt 6 development packages not found." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- drop `Qt5Compat` and `QTextCodec` usage
- update CI and build scripts for pure Qt6
- simplify run_cppcheck.sh
- clean up README instructions
- update Windows build modules

## Testing
- `pip install -r requirements.txt`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685aeeefde208322b94ab68837fd3fdb