### PR TITLE
Unify header guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,5 +20,6 @@ Thank you for considering a contribution! Please follow these steps when prepari
    ```
    The suite relies on `PySide6` and other packages from `requirements.txt`. Tests that
    depend on PySide6 will be skipped automatically if it is not available.
+5. Header files under `Waifu2x-Extension-QT` should use `#pragma once` for include guards.
 
 See the `README.md` for build instructions and additional details.

--- a/Waifu2x-Extension-QT/RealCuganProcessor.h
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.h
@@ -1,6 +1,5 @@
 // file: realcuganprocessor.h
-#ifndef REALCUGANPROCESSOR_H
-#define REALCUGANPROCESSOR_H
+#pragma once
 
 #include <QObject>
 #include <QProcess>
@@ -153,5 +152,3 @@ private:
     static const qint64 MAX_DECODED_BUFFER_SIZE = 100 * 1024 * 1024; // 100MB limit for decoded frames buffer
     static const qint64 MAX_UPSCALED_BUFFER_SIZE = 100 * 1024 * 1024; // 100MB limit for upscaled frames buffer
 };
-
-#endif // REALCUGANPROCESSOR_H

--- a/Waifu2x-Extension-QT/anime4k_settings.h
+++ b/Waifu2x-Extension-QT/anime4k_settings.h
@@ -16,8 +16,7 @@
 */
 
 // file: anime4k_settings.h
-#ifndef ANIME4K_SETTINGS_H
-#define ANIME4K_SETTINGS_H
+#pragma once
 
 #include <QString>
 
@@ -50,5 +49,3 @@ struct Anime4kSettings {
     int commandQueues;
     bool parallelIo;
 };
-
-#endif // ANIME4K_SETTINGS_H

--- a/Waifu2x-Extension-QT/anime4kprocessor.h
+++ b/Waifu2x-Extension-QT/anime4kprocessor.h
@@ -16,8 +16,7 @@
 */
 
 // file: anime4kprocessor.h
-#ifndef ANIME4KPROCESSOR_H
-#define ANIME4KPROCESSOR_H
+#pragma once
 
 #include <QObject>
 #include <QProcess> // <-- Add include
@@ -51,5 +50,3 @@ private:
     int m_currentRowNum;
     QString m_destinationFile;
 };
-
-#endif // ANIME4KPROCESSOR_H

--- a/Waifu2x-Extension-QT/mainwindow.h
+++ b/Waifu2x-Extension-QT/mainwindow.h
@@ -17,8 +17,7 @@
     My Github homepage: https://github.com/beyawnko
 */
 
-#ifndef MAINWINDOW_H
-#define MAINWINDOW_H
+#pragma once
 
 #include <QMainWindow>
 #include <QDragEnterEvent>
@@ -872,4 +871,3 @@ signals:
   void Send_Realcugan_ncnn_vulkan_DetectGPU_finished();
 
 };
-#endif // MAINWINDOW_H

--- a/Waifu2x-Extension-QT/realcugan_settings.h
+++ b/Waifu2x-Extension-QT/realcugan_settings.h
@@ -1,5 +1,4 @@
-#ifndef REALCUGAN_SETTINGS_H
-#define REALCUGAN_SETTINGS_H
+#pragma once
 
 #include <QString>
 
@@ -27,5 +26,3 @@ struct RealCuganSettings {
     int videoEncoderCRF = 23;
     QString videoOutputPixFmt = "yuv420p";
 };
-
-#endif // REALCUGAN_SETTINGS_H

--- a/Waifu2x-Extension-QT/realesrgan_settings.h
+++ b/Waifu2x-Extension-QT/realesrgan_settings.h
@@ -1,6 +1,5 @@
 // file: realesrgan_settings.h
-#ifndef REALESRGAN_SETTINGS_H
-#define REALESRGAN_SETTINGS_H
+#pragma once
 
 #include <QString>
 
@@ -16,5 +15,3 @@ struct RealEsrganSettings {
     // GPU Settings
     QString singleGpuId;
 };
-
-#endif // REALESRGAN_SETTINGS_H

--- a/Waifu2x-Extension-QT/realesrganprocessor.h
+++ b/Waifu2x-Extension-QT/realesrganprocessor.h
@@ -1,6 +1,5 @@
 // file: realesrganprocessor.h
-#ifndef REALESRGANPROCESSOR_H
-#define REALESRGANPROCESSOR_H
+#pragma once
 
 #include <QObject>
 #include <QProcess>
@@ -154,5 +153,3 @@ private:
     void pipeFrameToEncoder(const QByteArray& upscaledFrameData); // Common method, could be base class
     void finalizePipedVideoProcessing(bool success); // Common method, could be base class
 };
-
-#endif // REALESRGANPROCESSOR_H

--- a/memory/archival/2025-06-24T201233Z-header-guards.md
+++ b/memory/archival/2025-06-24T201233Z-header-guards.md
@@ -1,0 +1,7 @@
+# Standardize Header Guards
+
+Updated all headers in `Waifu2x-Extension-QT` to use `#pragma once`. Removed old `#ifndef`/`#define` patterns for consistency. Documented the requirement in `CONTRIBUTING.md`.
+
+Related memories:
+- [Drop Qt5Compat support](2025-06-24T183813Z-drop-qt5compat.md)
+- [Recent merges summary](2025-06-25-recent-merges-summary.md)


### PR DESCRIPTION
## Summary
- replace include guard macros with `#pragma once` in `Waifu2x-Extension-QT`
- note the chosen style in `CONTRIBUTING.md`
- record memory about guard standard

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685b049dbd58832298f6b9647ca22ddc