### PR TITLE
Add clazy static analysis workflow

### DIFF
--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -1,0 +1,25 @@
+name: clazy
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  clazy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Qt and clazy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev clazy bear
+      - name: Run clazy
+        run: |
+          ./tools/run_clazy.sh
+          head -n 20 clazy.log || true
+      - name: Upload clazy log
+        uses: actions/upload-artifact@v4
+        with:
+          name: clazy-log
+          path: clazy.log

--- a/README.md
+++ b/README.md
@@ -452,3 +452,28 @@ Run cppcheck from the repository root:
 The helper script automatically applies the arguments listed in `tools/cppcheck.cfg`. This file defines the Qt keywords
 (`slots`, `signals`, `Q_OBJECT`, …) so that cppcheck does not warn about them. The results are written to
 `cppcheck.log`. A GitHub Actions workflow runs cppcheck on each push and pull request.
+
+[![clazy]][clazy-link]
+
+`clazy` provides Qt-focused checks powered by clang. The helper script requires
+`clazy`, `bear` and the Qt development headers. Install them on Debian-based
+systems with:
+
+```bash
+sudo apt-get update
+sudo apt-get install qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev \
+    qt6-shadertools-dev clazy bear
+```
+
+Run clazy from the repository root:
+
+```bash
+./tools/run_clazy.sh
+```
+
+The script builds the project with clang under `bear` to capture compile
+commands and then runs `clazy-standalone`. The results are written to
+`clazy.log`. A GitHub Actions workflow executes clazy on each push and pull
+request.
+
+[clazy-link]: https://github.com/beyawnko/Beya_Waifu/actions/workflows/clazy.yml

--- a/memory/archival/2025-06-25T230000Z-clazy-checks.md
+++ b/memory/archival/2025-06-25T230000Z-clazy-checks.md
@@ -1,0 +1,7 @@
+# Integrate clazy static analysis
+
+Added a new clazy-based code check alongside cppcheck. The `tools/run_clazy.sh` script builds the Qt application with clang under `bear` to capture compilation commands and then runs `clazy-standalone`. A dedicated GitHub Actions workflow executes the script and uploads `clazy.log`.
+
+Related memories:
+- [waifu2x-extension-qt analysis](2025-06-23-waifu2x-extension-qt-analysis.md)
+- [Standardize Header Guards](2025-06-24T201233Z-header-guards.md)

--- a/tools/run_clazy.sh
+++ b/tools/run_clazy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+if ! command -v clazy-standalone >/dev/null 2>&1; then
+    echo "Error: clazy-standalone not found. Install clazy to run static analysis." >&2
+    exit 1
+fi
+
+if ! command -v qmake >/dev/null 2>&1; then
+    echo "Error: qmake not found. Ensure Qt development tools are installed." >&2
+    exit 1
+fi
+
+BUILD_DIR=clazy-build
+rm -rf "$BUILD_DIR"
+mkdir "$BUILD_DIR"
+
+pushd "$BUILD_DIR" >/dev/null
+qmake ../Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro -spec linux-clang CONFIG+=c++17
+if command -v bear >/dev/null 2>&1; then
+    bear -- make -j"$(nproc)"
+else
+    make -j"$(nproc)"
+fi
+popd >/dev/null
+
+clazy-standalone -p "$BUILD_DIR" --checks=level1 --header-filter='Waifu2x-Extension-QT/.*' > clazy.log
+
+echo "clazy analysis finished, results stored in clazy.log"


### PR DESCRIPTION
## Summary
- add GitHub Actions job to run clazy
- script to build with clang via bear and run clazy-standalone
- document how to run clazy locally
- record the addition in archival memory

## Testing
- `pip install -r requirements.txt`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_685b0373fa008322ad30f2f06a674aed