### PR TITLE
Add Qt dev tools for clazy

### DIFF
--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -13,7 +13,10 @@ jobs:
       - name: Install Qt and clazy
         run: |
           sudo apt-get update
-          sudo apt-get install -y qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev clazy bear
+          sudo apt-get install -y \
+            qtchooser qmake6 \
+            qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev \
+            clazy bear
       - name: Run clazy
         run: |
           ./tools/run_clazy.sh

--- a/tools/run_clazy.sh
+++ b/tools/run_clazy.sh
@@ -6,8 +6,13 @@ if ! command -v clazy-standalone >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! command -v qmake >/dev/null 2>&1; then
-    echo "Error: qmake not found. Ensure Qt development tools are installed." >&2
+QMAKE_CMD=""
+if command -v qmake6 >/dev/null 2>&1; then
+    QMAKE_CMD="qmake6"
+elif command -v qmake >/dev/null 2>&1; then
+    QMAKE_CMD="qmake"
+else
+    echo "Error: qmake or qmake6 not found. Ensure Qt development tools are installed." >&2
     exit 1
 fi
 
@@ -16,7 +21,7 @@ rm -rf "$BUILD_DIR"
 mkdir "$BUILD_DIR"
 
 pushd "$BUILD_DIR" >/dev/null
-qmake ../Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro -spec linux-clang CONFIG+=c++17
+$QMAKE_CMD ../Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro -spec linux-clang CONFIG+=c++17
 if command -v bear >/dev/null 2>&1; then
     bear -- make -j"$(nproc)"
 else


### PR DESCRIPTION
## Summary
- fix clazy workflow by installing Qt6-only packages
- update run_clazy script to prefer `qmake6`

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*


------
https://chatgpt.com/codex/tasks/task_e_685b0bd480308322b51518cbcbbb47d8