### PR TITLE
Add optional PyTorch checks for pnnx tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,15 @@ If `tests/test_qml_liquidglass.py` warns that `shaders/liquidglass.frag.qsb` is 
 automatically downloads the Linux releases of both upscalers if the executables are not present and places them in
 `tests/bin/`.
 
+The tests under `ncnn/tools/pnnx/tests` rely on the PyTorch ecosystem. Install `torch`,
+`torchaudio` and `torchvision` with:
+
+```bash
+pip install torch torchaudio torchvision
+```
+
+If these packages are missing the entire pnnx test suite is skipped.
+
 To execute the tests from the repository root simply run:
 
 ```bash

--- a/ncnn/tools/pnnx/tests/conftest.py
+++ b/ncnn/tools/pnnx/tests/conftest.py
@@ -1,0 +1,11 @@
+try:
+    import torch  # noqa: F401
+    import torchaudio  # noqa: F401
+    import torchvision  # noqa: F401
+    TORCH_AVAILABLE = True
+except Exception:
+    TORCH_AVAILABLE = False
+
+
+def pytest_ignore_collect(collection_path, config):
+    return not TORCH_AVAILABLE


### PR DESCRIPTION
## Summary
- skip the pnnx test suite if PyTorch or related packages are unavailable
- document PyTorch requirements for the pnnx tests

## Testing
- `pytest tests -q`
- `pytest ncnn/tools/pnnx/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0f70a68883229ba90e3b4adc8187