### PR TITLE
Build shader via qmake

### DIFF
--- a/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
+++ b/Waifu2x-Extension-QT/Waifu2x-Extension-QT.pro
@@ -5,8 +5,8 @@
 # (at your option) any later version.
 
 QT       += core gui concurrent multimedia opengl openglwidgets
-
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+QT       += shadertools
 
 CONFIG += c++17
 
@@ -100,15 +100,8 @@ RESOURCES += \
     style.qrc \
     shaders.qrc
 
-# compile GLSL shader to QSB
-liquidglass_frag.input = SHADER
-liquidglass_frag.files = $$PWD/shaders/liquidglass.frag
-liquidglass_frag.output = $$PWD/shaders/liquidglass.frag.qsb
-liquidglass_frag.commands = \
-    mkdir -p $$PWD/shaders && \
-    qsb "$$PWD/shaders/liquidglass.frag" -o "$$PWD/shaders/liquidglass.frag.qsb"
-liquidglass_frag.CONFIG = no_link
-QMAKE_EXTRA_TARGETS += liquidglass_frag
-PRE_TARGETDEPS += $$liquidglass_frag.output
+# shaders compiled automatically by qmake
+SHADERS += \
+    shaders/liquidglass.frag
 
 RC_ICONS = icon/icon.ico

--- a/memory/archival/2025-06-24T2105Z-liquidglass-shaders.md
+++ b/memory/archival/2025-06-24T2105Z-liquidglass-shaders.md
@@ -1,0 +1,8 @@
+### Summary
+- Added `QT += shadertools` and `SHADERS += shaders/liquidglass.frag` to Waifu2x-Extension-QT.pro
+- Removed custom qsb build commands
+- Tests failed due to missing pybind11_tests, ncnn, and Qt libraries
+
+Related memories:
+- [2025-06-18T091029Z-liquidglass-openGL.md](2025-06-18T091029Z-liquidglass-openGL.md)
+- [2025-06-18T195718Z-hdn-passes-fix.md](2025-06-18T195718Z-hdn-passes-fix.md)


### PR DESCRIPTION
## Summary
- use qmake `shadertools` with `SHADERS` variable
- document the change in memory

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*
- `sudo apt-get install -y libegl1`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*

------
https://chatgpt.com/codex/tasks/task_e_685b1263214c8322bc6d4c919c233f53