### PR TITLE
Fix RealCugan pipe encoder signature

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.h
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.h
@@ -145,7 +145,7 @@ private:
     void startRealCuganPipe(const QByteArray& frameData);
     void processSROutputBuffer();
     void startPipeEncoder();
-    void pipeFrameToEncoder();
+    void pipeFrameToEncoder(const QByteArray& upscaledFrameData);
     void finalizePipedVideoProcessing(bool success);
 
     // Constants for buffer limits

--- a/memory/archival/2025-06-24T214057Z-pipeframe-encoder-signature.md
+++ b/memory/archival/2025-06-24T214057Z-pipeframe-encoder-signature.md
@@ -1,0 +1,7 @@
+# Updated pipeFrameToEncoder signature
+
+Adjusted RealCuganProcessor.h so `pipeFrameToEncoder` accepts the upscaled frame data as a const QByteArray reference. This aligns the header with the implementation and call site in RealCuganProcessor.cpp.
+
+Related memories:
+- [2025-06-25T221500Z-consolidated-merge-summary-note.md](2025-06-25T221500Z-consolidated-merge-summary-note.md)
+- [2025-06-25T230000Z-clazy-checks.md](2025-06-25T230000Z-clazy-checks.md)


### PR DESCRIPTION
## Summary
- update `pipeFrameToEncoder` declaration to accept upscaled frame data
- document the change

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*

------
https://chatgpt.com/codex/tasks/task_e_685b1ab4e6688322828312ae22c535e4