### PR TITLE
Add QTimer include to processors

### DIFF
--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -7,6 +7,7 @@
 #include <QStandardPaths> // For temporary paths
 #include <QDateTime>      // For unique temp folder names
 #include <QFile>          // For QFile::remove
+#include <QTimer>
 
 RealCuganProcessor::RealCuganProcessor(QObject *parent) : QObject(parent)
 {

--- a/Waifu2x-Extension-QT/realesrganprocessor.cpp
+++ b/Waifu2x-Extension-QT/realesrganprocessor.cpp
@@ -8,6 +8,7 @@
 #include <QTime>       // For temporary file naming during multi-pass
 #include <QStandardPaths> // For temporary paths (new)
 #include <QFile>          // For QFile::remove (new)
+#include <QTimer>
 
 
 RealEsrganProcessor::RealEsrganProcessor(QObject *parent) : QObject(parent)

--- a/memory/archival/2025-06-24T220533Z-qtimer-include.md
+++ b/memory/archival/2025-06-24T220533Z-qtimer-include.md
@@ -1,0 +1,9 @@
+# Memory: Added QTimer include
+
+Included `#include <QTimer>` at the top of `RealCuganProcessor.cpp` and `realesrganprocessor.cpp`. These files call
+`QTimer::singleShot` so the explicit include prevents missing header errors with certain build configurations. All
+tests passed after the change.
+
+Related memories:
+- [RealCUGAN Qt Multimedia Pipeline Verification](2025-06-24T093757Z-realcugan-qt-media-check.md)
+- [Anime4K HDN passes enable fix](2025-06-18T195718Z-hdn-passes-fix.md)


### PR DESCRIPTION
## Summary
- include `<QTimer>` in `RealCuganProcessor.cpp`
- include `<QTimer>` in `realesrganprocessor.cpp`
- document the change in memory

## Testing
- `pip install -r requirements.txt`
- `sudo apt-get update`
- `sudo apt-get install -y libegl1`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685b206eaca08322915685ceb5bbe6d5