### PR TITLE
Fix Qt6 build by casting image size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ These protocols define the mandatory algorithms for your reasoning and task exec
     - *Build System and Dependency Analysis*: When planning tasks related to version migrations (e.g., Qt5 to Qt6), dependency updates, or troubleshooting build-level errors:
         - The plan must include a specific step to thoroughly inspect and analyze the project's build system files (e.g., `.pro`, `CMakeLists.txt`, `setup.py`).
         - This inspection should verify correct library versions, module inclusions, compiler flags (like `QT_DEPRECATED_WARNINGS`), and absence of conflicting or obsolete dependencies.
+        - When migrating between Qt versions, check source files for removed types (e.g., `imagesize_t`) and update them to their Qt 6 replacements (e.g., `qsizetype`).
     - *Inter-Process Communication (IPC) via Pipes*: When planning tasks involving the development or modification of features using IPC via pipes (e.g., chaining `QProcess` instances or similar):
         - The plan should include steps to verify robust error handling and propagation across all stages of the pipe.
         - Explicitly check for mechanisms to manage data buffering between processes to prevent excessive memory usage (e.g., backpressure, buffer limits).

--- a/Waifu2x-Extension-QT/RealCuganProcessor.cpp
+++ b/Waifu2x-Extension-QT/RealCuganProcessor.cpp
@@ -836,7 +836,7 @@ void RealCuganProcessor::processDecodedFrameBuffer() {
         return;
     }
 
-    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), imagesize_t(image.sizeInBytes()));
+    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), qsizetype(image.sizeInBytes()));
 
     if (m_currentDecodedFrameBuffer.isEmpty()) {
          emit logMessage(tr("Error: Converted QImage to QByteArray is empty. Skipping frame."));
@@ -1233,7 +1233,7 @@ void RealCuganProcessor::onQtVideoFrameChanged(const QVideoFrame &frame)
     }
 
     // Now m_currentDecodedFrameBuffer holds the raw pixels in BGR888 or RGB888 format
-    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), imagesize_t(image.sizeInBytes()));
+    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), qsizetype(image.sizeInBytes()));
 
 
     // At this point, m_currentDecodedFrameBuffer has one frame.

--- a/Waifu2x-Extension-QT/realesrganprocessor.cpp
+++ b/Waifu2x-Extension-QT/realesrganprocessor.cpp
@@ -999,7 +999,7 @@ void RealEsrganProcessor::onQtVideoFrameChanged(const QVideoFrame &frame)
         return;
     }
 
-    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), imagesize_t(image.sizeInBytes()));
+    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), qsizetype(image.sizeInBytes()));
     m_framesAcceptedBySR++;
     if (m_settings.verboseLog && m_framesAcceptedBySR % 100 == 0) {
          qDebug() << "RealESRGAN QVideoSink: Frame" << m_framesAcceptedBySR << "being sent to SR.";
@@ -1065,7 +1065,7 @@ void RealEsrganProcessor::processDecodedFrameBuffer() {
         return;
     }
 
-    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), imagesize_t(image.sizeInBytes()));
+    m_currentDecodedFrameBuffer = QByteArray(reinterpret_cast<const char*>(image.constBits()), qsizetype(image.sizeInBytes()));
     if (m_currentDecodedFrameBuffer.isEmpty()) {
         emit logMessage(tr("RealESRGAN Error: Converted QImage to QByteArray is empty. Skipping."));
         if (m_mediaPlayerPausedByBackpressure && m_mediaPlayer && m_mediaPlayer->playbackState() == QMediaPlayer::PausedState && m_qtVideoFrameBuffer.size() < 2) {

--- a/memory/archival/2025-06-24T221830Z-qsize-cast.md
+++ b/memory/archival/2025-06-24T221830Z-qsize-cast.md
@@ -1,0 +1,7 @@
+# Replace imagesize_t with qsizetype
+
+Replaced deprecated `imagesize_t(image.sizeInBytes())` casts with `qsizetype(image.sizeInBytes())` in `RealCuganProcessor.cpp` and `realesrganprocessor.cpp`. This aligns the code with Qt 6's API and resolves compilation issues.
+
+Related memories:
+- [Added QTimer include](2025-06-24T220533Z-qtimer-include.md)
+- [Integrate clazy static analysis](2025-06-25T230000Z-clazy-checks.md)


### PR DESCRIPTION
## Summary
- use `qsizetype` when building `QByteArray` from QImage data
- document the cast change in memory
- clarify Qt migration steps in `AGENTS.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685b2364d0d88322b2e062ed80950cde