### PR TITLE
Update CI to expose ncnn Python modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qt6-base-dev qt6-base-dev-tools qt6-multimedia-dev qt6-shadertools-dev libegl1 cppcheck qt6-declarative-dev qt6-tools-dev
           pip install -r requirements.txt
+          pip install numpy pybind11
+          echo "PYTHONPATH=$(pwd)/ncnn/python:$(pwd)/ncnn/tools/pnnx/python:$PYTHONPATH" >> $GITHUB_ENV
       - name: Static analysis
         run: |
           ./tools/run_cppcheck.sh
           cat cppcheck.log
       - name: Run tests
-        run: pytest
+        run: pytest -q tests
 
   build-windows:
     runs-on: windows-latest

--- a/memory/archival/2025-06-24T223635Z-ci-ncnn-pythonpath.md
+++ b/memory/archival/2025-06-24T223635Z-ci-ncnn-pythonpath.md
@@ -1,0 +1,7 @@
+# Memory: Ensure ncnn Python modules importable in CI
+
+Updated `.github/workflows/ci.yml` so the Linux job installs `numpy` and `pybind11` after requirements, then exports `PYTHONPATH` to include the repository's local `ncnn/python` and `ncnn/tools/pnnx/python` directories. The workflow also runs `pytest -q tests` to limit test discovery.
+
+Related memories:
+- [Follow AGENTS Instructions](2025-06-18-run-tests-patch-agents.md)
+- [Update cppcheck workflow to Qt6](2025-06-24T222821Z-qt6-cppcheck-workflow.md)


### PR DESCRIPTION
## Summary
- allow Python tests to import ncnn/pnnx by setting `PYTHONPATH`
- install numpy and pybind11 in CI
- run `pytest -q tests` in workflow
- document CI update in memory

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685b27777a9c8322beb9c99cd973aef4