### PR TITLE
Add Qt6 QA review memory

### DIFF
--- a/memory/archival/2025-06-24T224736Z-qt6-qa-review.md
+++ b/memory/archival/2025-06-24T224736Z-qt6-qa-review.md
@@ -1,0 +1,16 @@
+# Qt6 + C++17 QA Review
+
+## Summary
+Performed a read-only review of the repository to assess utilization of Qt6 features and modern C++17 techniques. The project targets Qt6 (see README.md lines 1-3) and compiles with C++17 per `Waifu2x-Extension-QT.pro` (CONFIG += c++17). Video decoding uses `QMediaPlayer` and `QVideoSink`.
+
+Areas for improvement:
+1. `tools/run_cppcheck.sh` enforces `--std=c++11`, which conflicts with C++17.
+2. Build system relies on qmake; Qt6 recommends CMake for better IDE and tooling integration.
+3. `LiquidGlassWidget` uses `QOpenGLWidget` and raw OpenGL; consider migrating to Qt6 RHI with shaders compiled via Qt Shader Tools.
+4. Asynchronous pipelines depend on `QtConcurrent::run` without using the modern `QFuture::then`/`QPromise` APIs for chaining tasks.
+5. Frame processing converts `QVideoFrame` to `QImage` via `toImage()`, which incurs a copy and CPU overhead.
+6. Repository includes `.pro.user` files referencing Qt 5.15, which are environment-specific and outdated.
+
+## Related Memories
+- [Drop Qt5Compat support](2025-06-24T183813Z-drop-qt5compat.md)
+- [LiquidGlass shader build](2025-06-24T2105Z-liquidglass-shaders.md)


### PR DESCRIPTION
## Summary
- add QA analysis memory referencing Qt6 usage and improvement areas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b2a718bc48322b6840a14e98208b5